### PR TITLE
[feat] API 응답통일 및 에러핸들러 세팅

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
     //Database
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
+    //jakarta
+    implementation("jakarta.validation:jakarta.validation-api:3.0.0")
+    implementation("org.hibernate.validator:hibernate-validator:6.2.0.Final")
 }
 
 

--- a/src/main/kotlin/cv/nmnb/global/response/base/BaseCode.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/base/BaseCode.kt
@@ -1,0 +1,7 @@
+package cv.nmnb.global.response.base
+
+import cv.nmnb.global.response.dto.ReasonDTO
+
+interface BaseCode {
+    fun getReasonHttpStatus(): ReasonDTO
+}

--- a/src/main/kotlin/cv/nmnb/global/response/base/BaseErrorCode.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/base/BaseErrorCode.kt
@@ -1,0 +1,7 @@
+package cv.nmnb.global.response.base
+
+import cv.nmnb.global.response.dto.ErrorReasonDTO
+
+interface BaseErrorCode {
+    fun getReasonHttpStatus(): ErrorReasonDTO
+}

--- a/src/main/kotlin/cv/nmnb/global/response/base/BaseResponse.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/base/BaseResponse.kt
@@ -1,0 +1,38 @@
+package cv.nmnb.global.response.base
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+
+@JsonPropertyOrder("code", "message", "result", "isSuccess")
+class BaseResponse<T>(
+    val code: String,
+    val message: String,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val result: T,
+    @JsonProperty("isSuccess")
+    val isSuccess: Boolean = true,
+) {
+    companion object {
+        fun <T> onSuccess(code: BaseCode, data: T): BaseResponse<T> {
+            return of(true, code, data)
+        }
+
+        private fun <T> of(isSuccess: Boolean, code: BaseCode, result: T): BaseResponse<T> {
+            return BaseResponse<T>(
+                code.getReasonHttpStatus().code,
+                code.getReasonHttpStatus().message,
+                result,
+                isSuccess,
+            )
+        }
+
+        fun <T> onFailure(code: BaseCode, data: T): BaseResponse<T> {
+            return of(false, code, data)
+        }
+
+        fun <T> onFailure(code: String, message: String, data: T): BaseResponse<T> {
+            return BaseResponse<T>(code, message, data, false)
+        }
+    }
+}

--- a/src/main/kotlin/cv/nmnb/global/response/dto/ErrorReasonDTO.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/dto/ErrorReasonDTO.kt
@@ -1,0 +1,10 @@
+package cv.nmnb.global.response.dto
+
+import org.springframework.http.HttpStatus
+
+data class ErrorReasonDTO(
+    val httpStatus: HttpStatus,
+    val code: String,
+    val message: String,
+    val isSuccess: Boolean = false,
+)

--- a/src/main/kotlin/cv/nmnb/global/response/dto/ReasonDTO.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/dto/ReasonDTO.kt
@@ -1,0 +1,10 @@
+package cv.nmnb.global.response.dto
+
+import org.springframework.http.HttpStatus
+
+data class ReasonDTO(
+    val httpStatus: HttpStatus,
+    val code: String,
+    val message: String,
+    val isSuccess: Boolean = true,
+)

--- a/src/main/kotlin/cv/nmnb/global/response/exception/ExceptionAdvice.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/exception/ExceptionAdvice.kt
@@ -1,0 +1,110 @@
+package cv.nmnb.global.response.exception
+
+import cv.nmnb.global.response.base.BaseResponse
+import cv.nmnb.global.response.dto.ErrorReasonDTO
+import cv.nmnb.global.response.status.ErrorStatus
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+@RestControllerAdvice(annotations = [RestController::class])
+class ExceptionAdvice : ResponseEntityExceptionHandler() {
+    private fun handleException(
+        e: Exception,
+        errorStatus: ErrorStatus,
+        errorMessage: String,
+        headers: HttpHeaders,
+        request: WebRequest,
+    ): ResponseEntity<Any>? {
+        val body = BaseResponse.onFailure(
+            errorStatus.code,
+            errorStatus.message,
+            errorMessage,
+        )
+        return super.handleExceptionInternal(e, body, headers, errorStatus.httpStatus, request)
+    }
+
+    @ExceptionHandler
+    fun exception(e: Exception, request: WebRequest): ResponseEntity<Any>? {
+        return handleException(e, ErrorStatus.INTERNAL_SERVER_ERROR, e.message.toString(), HttpHeaders.EMPTY, request)
+    }
+
+    @ExceptionHandler
+    fun validation(e: ConstraintViolationException, request: WebRequest): ResponseEntity<Any>? {
+        val errorMessage = e.constraintViolations
+            .map { it.message }
+            .reduceOrNull { acc, msg -> "$acc, $msg" }
+            ?: "Validation error occurred"
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request)
+    }
+
+    private fun handleExceptionInternalConstraint(
+        e: Exception,
+        errorCommonStatus: ErrorStatus,
+        headers: HttpHeaders,
+        request: WebRequest,
+    ): ResponseEntity<Any>? {
+        val body = BaseResponse.onFailure(errorCommonStatus.code, errorCommonStatus.message, null)
+        return super.handleExceptionInternal(e, body, headers, errorCommonStatus.httpStatus!!, request)
+    }
+
+    @ExceptionHandler(value = [GeneralException::class])
+    fun onThrowException(
+        generalException: GeneralException,
+        request: HttpServletRequest,
+    ): ResponseEntity<Any>? {
+        val errorReasonHttpStatus = generalException.getErrorReasonHttpStatus()
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, HttpHeaders(), request)
+    }
+
+    private fun handleExceptionInternal(
+        e: Exception,
+        reason: ErrorReasonDTO,
+        headers: HttpHeaders,
+        request: HttpServletRequest,
+    ): ResponseEntity<Any>? {
+        val body = BaseResponse.onFailure(reason.code, reason.message, null)
+        val webRequest: WebRequest = ServletWebRequest(request)
+
+        return super.handleExceptionInternal(e, body, headers, reason.httpStatus, webRequest)
+    }
+
+    override fun handleMethodArgumentNotValid(
+        e: MethodArgumentNotValidException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any>? {
+        val errors = LinkedHashMap<String, String>()
+        e.bindingResult
+            .fieldErrors
+            .forEach {
+                    fieldError,
+                ->
+                errors[fieldError.field] = fieldError.defaultMessage ?: ""
+            }
+        return handleExceptionInternalArgs(e, request, errors)
+    }
+
+    private fun handleExceptionInternalArgs(
+        e: Exception,
+        request: WebRequest,
+        errorArgs: Map<String, String>,
+    ): ResponseEntity<Any>? {
+        val body = BaseResponse.onFailure(
+            ErrorStatus.BAD_REQUEST.code,
+            ErrorStatus.BAD_REQUEST.message,
+            errorArgs,
+        )
+        return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, ErrorStatus.BAD_REQUEST.httpStatus!!, request)
+    }
+}

--- a/src/main/kotlin/cv/nmnb/global/response/exception/GeneralException.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/exception/GeneralException.kt
@@ -1,0 +1,13 @@
+package cv.nmnb.global.response.exception
+
+import cv.nmnb.global.response.base.BaseErrorCode
+import cv.nmnb.global.response.dto.ErrorReasonDTO
+
+open class GeneralException(
+    private val code: BaseErrorCode,
+) : RuntimeException() {
+
+    fun getErrorReasonHttpStatus(): ErrorReasonDTO {
+        return this.code.getReasonHttpStatus()
+    }
+}

--- a/src/main/kotlin/cv/nmnb/global/response/status/ErrorStatus.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/status/ErrorStatus.kt
@@ -1,0 +1,21 @@
+package cv.nmnb.global.response.status
+
+import cv.nmnb.global.response.base.BaseErrorCode
+import cv.nmnb.global.response.dto.ErrorReasonDTO
+import org.springframework.http.HttpStatus
+
+enum class ErrorStatus(
+    val httpStatus: HttpStatus,
+    val code: String,
+    val message: String,
+) : BaseErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    ;
+
+    override fun getReasonHttpStatus(): ErrorReasonDTO {
+        return ErrorReasonDTO(httpStatus, code, message)
+    }
+}

--- a/src/main/kotlin/cv/nmnb/global/response/status/SuccessStatus.kt
+++ b/src/main/kotlin/cv/nmnb/global/response/status/SuccessStatus.kt
@@ -1,0 +1,20 @@
+package cv.nmnb.global.response.status
+
+import cv.nmnb.global.response.base.BaseCode
+import cv.nmnb.global.response.dto.ReasonDTO
+import org.springframework.http.HttpStatus
+
+enum class SuccessStatus(
+    val httpStatus: HttpStatus,
+    val code: String,
+    val message: String,
+) : BaseCode {
+    OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    CREATED(HttpStatus.CREATED, "COMMON201", "요청 성공 및 리소스 생성됨"),
+    NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON202", "요청 성공 및 반환할 콘텐츠가 없음"),
+    ;
+
+    override fun getReasonHttpStatus(): ReasonDTO {
+        return ReasonDTO(httpStatus, code, message)
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #5 

## 📌 개요
- 기존 케어비전에서 사용하던 부분과 거의 유사합니다! 근데 이제 언어만 달라진... 
   -> 케비 pr : https://github.com/SSU-Capstone-Aurora/CareVision-Backend/pull/13

**[달라진 점]** 
기존에 `onSuccess` 메서드를 사용해서 다른 에러 코드를 지정하더라도 코드가 무조건 `200`으로 넘어오는 문제가 있었던 것 같은데,
```
return new BaseResponse<>(
                true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), data);
```
다음과 같이 `SuccessStatus`의 경우를 무조건 지정해줬기 때문이었습니다. 

그 문제를 해결하기 위해서 아래와 같이 코드를 변경했습니다. 
```
fun <T> onSuccess(code: BaseCode, data: T): BaseResponse<T> {
      return of(true, code, data)
  }

  private fun <T> of(isSuccess: Boolean, code: BaseCode, result: T): BaseResponse<T> {
      return BaseResponse<T>(
          code.getReasonHttpStatus().code,
          code.getReasonHttpStatus().message,
          result,
          isSuccess,
      )
  }

  fun <T> onFailure(code: BaseCode, data: T): BaseResponse<T> {
      return of(false, code, data)
  }

```
그래서 이렇게 바꾸는 김에 기존에는 BaseResponse.of(...) 처럼 `of `를 사용했었는데, success 와 failure 상태를 더 명확하게 나타내기 위해 `onSuccess`, `onFailure`를 사용할 수 있도록하는게 더 좋을 것 같다고 판단했습니다! 이렇게 변경하면서 `of`를 사용할 일이 없을 거 같아서 `of `메서드는 `private`으로 돌려두었습니다.


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
