### PR TITLE
[feat] 반려견 미보유 상태 등록 API 구현

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import nmnb.application.domain.user.service.UserService
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
-import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.common.response.base.BaseResponse
 import nmnb.common.response.status.SuccessStatus
@@ -33,14 +33,14 @@ class UserController(
     @Operation(summary = "반려견 이름 등록 API", description = "가입하는 유저가 반려견의 이름을 등록합니다. 유저의 petOwnershipStatus가 `HAS_PET`으로 설정됩니다._예림")
     @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
     @PatchMapping("/pet")
-    fun setPetOwnershipWithName(@RequestBody request: UserPetRegistrationRequest): BaseResponse<UserPetStatusResponse> {
-        return BaseResponse.onSuccess(SuccessStatus.OK, userService.setPetOwnershipWithName(User.fixture("AuthUser 구현 후 수정"), request.petName))
+    fun registerWithPetName(@RequestBody request: UserPetRegistrationRequest): BaseResponse<UserStatusResponse> {
+        return BaseResponse.onSuccess(SuccessStatus.OK, userService.registerWithPetName(User.fixture("AuthUser 구현 후 수정"), request.petName))
     }
 
     @Operation(summary = "반려견 미보유 상태 설정 API", description = "가입하는 유저가 반려견을 보유하지 않았음을 설정합니다. petOwnershipStatus가 NO_PET으로 설정됩니다._예림")
     @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
     @PatchMapping("/pet/none")
-    fun setNoPetOwnership(): BaseResponse<UserPetStatusResponse> {
-        return BaseResponse.onSuccess(SuccessStatus.OK, userService.setNoPetOwnership(User.fixture("AuthUser 구현 후 수정")))
+    fun registerWithoutPet(): BaseResponse<UserStatusResponse> {
+        return BaseResponse.onSuccess(SuccessStatus.OK, userService.registerWithoutPet(User.fixture("AuthUser 구현 후 수정")))
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
@@ -34,6 +34,13 @@ class UserController(
     @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
     @PatchMapping("/pet")
     fun setPetOwnershipWithName(@RequestBody request: UserPetRegistrationRequest): BaseResponse<UserPetStatusResponse> {
-        return BaseResponse.onSuccess(SuccessStatus.OK, userService.registerWithPet(User.fixture("AuthUser 구현 후 수정"), request.petName))
+        return BaseResponse.onSuccess(SuccessStatus.OK, userService.setPetOwnershipWithName(User.fixture("AuthUser 구현 후 수정"), request.petName))
+    }
+
+    @Operation(summary = "반려견 미보유 상태 설정 API", description = "가입하는 유저가 반려견을 보유하지 않았음을 설정합니다. petOwnershipStatus가 NO_PET으로 설정됩니다._예림")
+    @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
+    @PatchMapping("/pet/none")
+    fun setNoPetOwnership(): BaseResponse<UserPetStatusResponse> {
+        return BaseResponse.onSuccess(SuccessStatus.OK, userService.setNoPetOwnership(User.fixture("AuthUser 구현 후 수정")))
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import nmnb.application.domain.user.service.UserService
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
-import nmnb.application.domain.user.service.dto.response.UserPetRegistrationResponse
+import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.common.response.base.BaseResponse
 import nmnb.common.response.status.SuccessStatus
@@ -30,10 +30,10 @@ class UserController(
         return BaseResponse.onSuccess(SuccessStatus.OK, userService.getProfile(user))
     }
 
-    @Operation(summary = "반려견 이름 등록 API", description = "가입하는 유저가 반려견의 이름을 등록합니다. hasAnimal이 true가 됩니다._예림")
+    @Operation(summary = "반려견 이름 등록 API", description = "가입하는 유저가 반려견의 이름을 등록합니다. 유저의 petOwnershipStatus가 `HAS_PET`으로 설정됩니다._예림")
     @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
     @PatchMapping("/pet")
-    fun registerPet(@RequestBody request: UserPetRegistrationRequest): BaseResponse<UserPetRegistrationResponse> {
-        return BaseResponse.onSuccess(SuccessStatus.OK, userService.registerPet(User.fixture("AuthUser 구현 후 수정"), request.petName))
+    fun setPetOwnershipWithName(@RequestBody request: UserPetRegistrationRequest): BaseResponse<UserPetStatusResponse> {
+        return BaseResponse.onSuccess(SuccessStatus.OK, userService.registerWithPet(User.fixture("AuthUser 구현 후 수정"), request.petName))
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import nmnb.application.domain.user.service.UserService
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
-import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.common.response.base.BaseResponse
 import nmnb.common.response.status.SuccessStatus
 import nmnb.domain.user.User

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserService.kt
@@ -1,7 +1,7 @@
 package nmnb.application.domain.user.service
 
-import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.domain.user.User
 
 interface UserService {

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserService.kt
@@ -1,10 +1,11 @@
 package nmnb.application.domain.user.service
 
-import nmnb.application.domain.user.service.dto.response.UserPetRegistrationResponse
+import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.domain.user.User
 
 interface UserService {
     fun getProfile(user: User): UserProfileResponse
-    fun registerPet(user: User, petName: String): UserPetRegistrationResponse
+    fun setPetOwnershipWithName(user: User, petName: String): UserPetStatusResponse
+    fun setNoPetOwnership(user: User): UserPetStatusResponse
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserService.kt
@@ -1,11 +1,11 @@
 package nmnb.application.domain.user.service
 
-import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.domain.user.User
 
 interface UserService {
     fun getProfile(user: User): UserProfileResponse
-    fun setPetOwnershipWithName(user: User, petName: String): UserPetStatusResponse
-    fun setNoPetOwnership(user: User): UserPetStatusResponse
+    fun registerWithPetName(user: User, petName: String): UserStatusResponse
+    fun registerWithoutPet(user: User): UserStatusResponse
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserServiceImpl.kt
@@ -1,8 +1,9 @@
 package nmnb.application.domain.user.service
 
-import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.domain.user.PetOwnershipStatus
+import nmnb.domain.user.SignUpStatus
 import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
@@ -19,15 +20,20 @@ class UserServiceImpl(
     }
 
     @Transactional
-    override fun setPetOwnershipWithName(user: User, petName: String): UserPetStatusResponse {
+    override fun registerWithPetName(user: User, petName: String): UserStatusResponse {
         user.updatePetName(petName)
-        user.updatePetOwnershipStatus(PetOwnershipStatus.HAS_PET)
-        return UserPetStatusResponse.of(userRepository.save(user))
+        completeRegistration(user, PetOwnershipStatus.HAS_PET)
+        return UserStatusResponse.of(userRepository.save(user))
     }
 
     @Transactional
-    override fun setNoPetOwnership(user: User): UserPetStatusResponse {
-        user.updatePetOwnershipStatus(PetOwnershipStatus.NO_PET)
-        return UserPetStatusResponse.of(userRepository.save(user))
+    override fun registerWithoutPet(user: User): UserStatusResponse {
+        completeRegistration(user, PetOwnershipStatus.NO_PET)
+        return UserStatusResponse.of(userRepository.save(user))
+    }
+
+    private fun completeRegistration(user: User, petOwnershipStatus: PetOwnershipStatus) {
+        user.updatePetOwnershipStatus(petOwnershipStatus)
+        user.updateSignUpStatus(SignUpStatus.COMPLETE)
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserServiceImpl.kt
@@ -1,6 +1,6 @@
 package nmnb.application.domain.user.service
 
-import nmnb.application.domain.user.service.dto.response.UserPetRegistrationResponse
+import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.User
@@ -19,9 +19,15 @@ class UserServiceImpl(
     }
 
     @Transactional
-    override fun registerPet(user: User, petName: String): UserPetRegistrationResponse {
+    override fun setPetOwnershipWithName(user: User, petName: String): UserPetStatusResponse {
         user.updatePetName(petName)
         user.updatePetOwnershipStatus(PetOwnershipStatus.HAS_PET)
-        return UserPetRegistrationResponse.of(userRepository.save(user))
+        return UserPetStatusResponse.of(userRepository.save(user))
+    }
+
+    @Transactional
+    override fun setNoPetOwnership(user: User): UserPetStatusResponse {
+        user.updatePetOwnershipStatus(PetOwnershipStatus.NO_PET)
+        return UserPetStatusResponse.of(userRepository.save(user))
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/UserServiceImpl.kt
@@ -1,7 +1,7 @@
 package nmnb.application.domain.user.service
 
-import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.SignUpStatus
 import nmnb.domain.user.User

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserPetRegistrationResponse.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserPetRegistrationResponse.kt
@@ -1,16 +1,17 @@
 package nmnb.application.domain.user.service.dto.response
 
+import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.User
 
 data class UserPetRegistrationResponse(
     val petName: String?,
-    val hasAnimal: Boolean,
+    val petOwnershipStatus: PetOwnershipStatus,
 ) {
     companion object {
         fun of(user: User): UserPetRegistrationResponse {
             return UserPetRegistrationResponse(
                 petName = user.petName,
-                hasAnimal = user.hasAnimal,
+                petOwnershipStatus = user.petOwnershipStatus,
             )
         }
     }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserPetStatusResponse.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserPetStatusResponse.kt
@@ -3,14 +3,14 @@ package nmnb.application.domain.user.service.dto.response
 import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.User
 
-data class UserPetRegistrationResponse(
-    val petName: String?,
+data class UserPetStatusResponse(
+    val nickName: String?,
     val petOwnershipStatus: PetOwnershipStatus,
 ) {
     companion object {
-        fun of(user: User): UserPetRegistrationResponse {
-            return UserPetRegistrationResponse(
-                petName = user.petName,
+        fun of(user: User): UserPetStatusResponse {
+            return UserPetStatusResponse(
+                nickName = user.nickName,
                 petOwnershipStatus = user.petOwnershipStatus,
             )
         }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserProfileResponse.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserProfileResponse.kt
@@ -1,12 +1,13 @@
 package nmnb.application.domain.user.service.dto.response
 
 import nmnb.common.utils.DateTimeUtils
+import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.User
 
 data class UserProfileResponse(
     val nickName: String,
     val profileImage: String,
-    val hasAnimal: Boolean,
+    val petOwnershipStatus: PetOwnershipStatus,
     val createdAt: String,
 ) {
     companion object {
@@ -14,7 +15,7 @@ data class UserProfileResponse(
             return UserProfileResponse(
                 nickName = user.nickName,
                 profileImage = user.profileImage,
-                hasAnimal = user.hasAnimal,
+                petOwnershipStatus = user.petOwnershipStatus,
                 createdAt = DateTimeUtils.formatDate(user.createdAt),
             )
         }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserStatusResponse.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserStatusResponse.kt
@@ -14,7 +14,7 @@ data class UserStatusResponse(
             return UserStatusResponse(
                 nickName = user.nickName,
                 petOwnershipStatus = user.petOwnershipStatus,
-                signUpStatus = user.signUpStatus
+                signUpStatus = user.signUpStatus,
             )
         }
     }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserStatusResponse.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/service/dto/response/UserStatusResponse.kt
@@ -1,17 +1,20 @@
 package nmnb.application.domain.user.service.dto.response
 
 import nmnb.domain.user.PetOwnershipStatus
+import nmnb.domain.user.SignUpStatus
 import nmnb.domain.user.User
 
-data class UserPetStatusResponse(
-    val nickName: String?,
+data class UserStatusResponse(
+    val nickName: String,
     val petOwnershipStatus: PetOwnershipStatus,
+    val signUpStatus: SignUpStatus,
 ) {
     companion object {
-        fun of(user: User): UserPetStatusResponse {
-            return UserPetStatusResponse(
+        fun of(user: User): UserStatusResponse {
+            return UserStatusResponse(
                 nickName = user.nickName,
                 petOwnershipStatus = user.petOwnershipStatus,
+                signUpStatus = user.signUpStatus
             )
         }
     }

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/auth/service/AuthServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/auth/service/AuthServiceImpl.kt
@@ -21,11 +21,11 @@ class AuthServiceImpl(
         val profile = oAuthClientComposite.getClient(type).requestProfile(accessCode = accessCode)
         val email = profile.getEmail()
 
-        userRepository.findByEmail(email) ?: userRepository.save(User(email, profileImage = s3Properties.defaultProfileImageUrl))
+        val user = userRepository.findByEmail(email) ?: userRepository.save(User(email, profileImage = s3Properties.defaultProfileImageUrl))
 
         val accessToken = tokenProvider.createAccessToken(email)
         val refreshToken = tokenProvider.createRefreshToken(email)
 
-        return AuthUserResponse(email, accessToken = accessToken, refreshToken = refreshToken)
+        return AuthUserResponse(email, accessToken = accessToken, refreshToken = refreshToken, signUpStatus = user.signUpStatus)
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/auth/service/dto/response/AuthUserResponse.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/auth/service/dto/response/AuthUserResponse.kt
@@ -1,7 +1,10 @@
 package nmnb.application.global.auth.service.dto.response
 
+import nmnb.domain.user.SignUpStatus
+
 data class AuthUserResponse(
     val email: String,
     val accessToken: String,
     val refreshToken: String,
+    val signUpStatus: SignUpStatus,
 )

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
@@ -2,8 +2,8 @@ package nmnb.application.domain.user.controller
 
 import nmnb.application.ControllerTestSupport
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
-import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.common.response.status.SuccessStatus
 import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.SignUpStatus

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
@@ -5,6 +5,7 @@ import nmnb.application.domain.user.service.dto.request.UserPetRegistrationReque
 import nmnb.application.domain.user.service.dto.response.UserPetRegistrationResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.common.response.status.SuccessStatus
+import nmnb.domain.user.PetOwnershipStatus
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -29,7 +30,7 @@ class UserControllerTest() : ControllerTestSupport() {
                 UserProfileResponse(
                     "nickname",
                     "profile",
-                    true,
+                    PetOwnershipStatus.HAS_PET,
                     "2025.01.02",
                 ),
             )
@@ -54,7 +55,7 @@ class UserControllerTest() : ControllerTestSupport() {
             .andExpect(jsonPath("$.code").value(SuccessStatus.OK.code))
             .andExpect(jsonPath("$.result.nickName").value("nickname"))
             .andExpect(jsonPath("$.result.profileImage").value("profile"))
-            .andExpect(jsonPath("$.result.hasAnimal").value(true))
+            .andExpect(jsonPath("$.result.petOwnershipStatus").value("HAS_PET"))
             .andExpect(jsonPath("$.result.createdAt").isNotEmpty)
     }
 
@@ -68,7 +69,7 @@ class UserControllerTest() : ControllerTestSupport() {
             .thenReturn(
                 UserPetRegistrationResponse(
                     petName = "멍멍이",
-                    hasAnimal = true,
+                    petOwnershipStatus = PetOwnershipStatus.HAS_PET,
                 ),
             )
 
@@ -84,6 +85,6 @@ class UserControllerTest() : ControllerTestSupport() {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.code").value(SuccessStatus.OK.code))
             .andExpect(jsonPath("$.result.petName").value("멍멍이"))
-            .andExpect(jsonPath("$.result.hasAnimal").value(true))
+            .andExpect(jsonPath("$.result.petOwnershipStatus").value("HAS_PET"))
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
@@ -2,7 +2,7 @@ package nmnb.application.domain.user.controller
 
 import nmnb.application.ControllerTestSupport
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
-import nmnb.application.domain.user.service.dto.response.UserPetRegistrationResponse
+import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.common.response.status.SuccessStatus
 import nmnb.domain.user.PetOwnershipStatus
@@ -60,15 +60,15 @@ class UserControllerTest() : ControllerTestSupport() {
     }
 
     @WithMockUser
-    @DisplayName("반려견 이름 등록에 성공한다")
+    @DisplayName("반려견의 이름을 등록 및 반려견 소유 상태 설정에 성공한다")
     @Test
-    fun registerPet() {
+    fun setPetOwnershipWithName() {
         // given
         val request = UserPetRegistrationRequest(petName = "멍멍이")
-        whenever(userService.registerPet(any(), any()))
+        whenever(userService.setPetOwnershipWithName(any(), any()))
             .thenReturn(
-                UserPetRegistrationResponse(
-                    petName = "멍멍이",
+                UserPetStatusResponse(
+                    nickName = "멍멍이-{랜덤값}",
                     petOwnershipStatus = PetOwnershipStatus.HAS_PET,
                 ),
             )
@@ -84,7 +84,32 @@ class UserControllerTest() : ControllerTestSupport() {
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.code").value(SuccessStatus.OK.code))
-            .andExpect(jsonPath("$.result.petName").value("멍멍이"))
+            .andExpect(jsonPath("$.result.nickName").value("멍멍이-{랜덤값}"))
             .andExpect(jsonPath("$.result.petOwnershipStatus").value("HAS_PET"))
+    }
+
+    @WithMockUser
+    @DisplayName("반려견 미보유 상태 등록에 성공한다")
+    @Test
+    fun setNoPetOwnership() {
+        // given
+        whenever(userService.setNoPetOwnership(any()))
+            .thenReturn(
+                UserPetStatusResponse(
+                    nickName = "{랜덤값}",
+                    petOwnershipStatus = PetOwnershipStatus.NO_PET,
+                ),
+            )
+
+        // when & then
+        mockMvc.perform(
+            patch("/v1/api/users/pet/none")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.code").value(SuccessStatus.OK.code))
+            .andExpect(jsonPath("$.result.nickName").value("{랜덤값}"))
+            .andExpect(jsonPath("$.result.petOwnershipStatus").value("NO_PET"))
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/controller/UserControllerTest.kt
@@ -2,10 +2,11 @@ package nmnb.application.domain.user.controller
 
 import nmnb.application.ControllerTestSupport
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
-import nmnb.application.domain.user.service.dto.response.UserPetStatusResponse
+import nmnb.application.domain.user.service.dto.response.UserStatusResponse
 import nmnb.application.domain.user.service.dto.response.UserProfileResponse
 import nmnb.common.response.status.SuccessStatus
 import nmnb.domain.user.PetOwnershipStatus
+import nmnb.domain.user.SignUpStatus
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -62,14 +63,15 @@ class UserControllerTest() : ControllerTestSupport() {
     @WithMockUser
     @DisplayName("반려견의 이름을 등록 및 반려견 소유 상태 설정에 성공한다")
     @Test
-    fun setPetOwnershipWithName() {
+    fun registerWithPetName() {
         // given
         val request = UserPetRegistrationRequest(petName = "멍멍이")
-        whenever(userService.setPetOwnershipWithName(any(), any()))
+        whenever(userService.registerWithPetName(any(), any()))
             .thenReturn(
-                UserPetStatusResponse(
+                UserStatusResponse(
                     nickName = "멍멍이-{랜덤값}",
                     petOwnershipStatus = PetOwnershipStatus.HAS_PET,
+                    signUpStatus = SignUpStatus.COMPLETE,
                 ),
             )
 
@@ -86,18 +88,20 @@ class UserControllerTest() : ControllerTestSupport() {
             .andExpect(jsonPath("$.code").value(SuccessStatus.OK.code))
             .andExpect(jsonPath("$.result.nickName").value("멍멍이-{랜덤값}"))
             .andExpect(jsonPath("$.result.petOwnershipStatus").value("HAS_PET"))
+            .andExpect(jsonPath("$.result.signUpStatus").value("COMPLETE"))
     }
 
     @WithMockUser
     @DisplayName("반려견 미보유 상태 등록에 성공한다")
     @Test
-    fun setNoPetOwnership() {
+    fun registerWithoutPet() {
         // given
-        whenever(userService.setNoPetOwnership(any()))
+        whenever(userService.registerWithoutPet(any()))
             .thenReturn(
-                UserPetStatusResponse(
+                UserStatusResponse(
                     nickName = "{랜덤값}",
                     petOwnershipStatus = PetOwnershipStatus.NO_PET,
+                    signUpStatus = SignUpStatus.COMPLETE,
                 ),
             )
 
@@ -111,5 +115,6 @@ class UserControllerTest() : ControllerTestSupport() {
             .andExpect(jsonPath("$.code").value(SuccessStatus.OK.code))
             .andExpect(jsonPath("$.result.nickName").value("{랜덤값}"))
             .andExpect(jsonPath("$.result.petOwnershipStatus").value("NO_PET"))
+            .andExpect(jsonPath("$.result.signUpStatus").value("COMPLETE"))
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
@@ -31,9 +31,9 @@ class UserServiceImplTest(
         Assertions.assertThat(result.petOwnershipStatus).isEqualTo(user.petOwnershipStatus)
     }
 
-    @DisplayName("반려견을 등록한다")
+    @DisplayName("반려견의 이름을 등록하고 반려견 소유 상태를 설정한다")
     @Test
-    fun registerPet() {
+    fun setPetOwnershipWithName() {
         // given
         val user = User.fixture(
             id = "test",
@@ -44,10 +44,28 @@ class UserServiceImplTest(
         val request = UserPetRegistrationRequest(petName = "멍멍이")
 
         // when
-        val result = userService.registerPet(user, request.petName)
+        val result = userService.setPetOwnershipWithName(user, request.petName)
 
         // then
-        Assertions.assertThat(result.petName).isEqualTo("멍멍이")
+        Assertions.assertThat(result.nickName).contains("멍멍이")
         Assertions.assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.HAS_PET)
+    }
+
+    @DisplayName("반려견 미보유 상태로 설정한다")
+    @Test
+    fun setNoPetOwnership() {
+        // given
+        val user = User.fixture(
+            id = "test",
+            petName = null,
+            petOwnershipStatus = PetOwnershipStatus.UNKNOWN,
+        )
+
+        // when
+        val result = userService.setNoPetOwnership(user)
+
+        // then
+        Assertions.assertThat(result.nickName).isNotBlank()
+        Assertions.assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.NO_PET)
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
@@ -3,8 +3,9 @@ package nmnb.application.domain.user.service
 import nmnb.application.IntegrationTestSupport
 import nmnb.application.domain.user.service.dto.request.UserPetRegistrationRequest
 import nmnb.domain.user.PetOwnershipStatus
+import nmnb.domain.user.SignUpStatus
 import nmnb.domain.user.User
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -26,46 +27,51 @@ class UserServiceImplTest(
         val result = userService.getProfile(user)
 
         // then
-        Assertions.assertThat(result.nickName).isEqualTo(user.nickName)
-        Assertions.assertThat(result.profileImage).isEqualTo(user.profileImage)
-        Assertions.assertThat(result.petOwnershipStatus).isEqualTo(user.petOwnershipStatus)
+        assertThat(result.nickName).isEqualTo(user.nickName)
+        assertThat(result.profileImage).isEqualTo(user.profileImage)
+        assertThat(result.petOwnershipStatus).isEqualTo(user.petOwnershipStatus)
+
     }
 
     @DisplayName("반려견의 이름을 등록하고 반려견 소유 상태를 설정한다")
     @Test
-    fun setPetOwnershipWithName() {
+    fun registerWithPetName() {
         // given
         val user = User.fixture(
             id = "test",
             petName = null,
             petOwnershipStatus = PetOwnershipStatus.UNKNOWN,
+            signUpStatus = SignUpStatus.IN_PROGRESS
         )
 
         val request = UserPetRegistrationRequest(petName = "멍멍이")
 
         // when
-        val result = userService.setPetOwnershipWithName(user, request.petName)
+        val result = userService.registerWithPetName(user, request.petName)
 
         // then
-        Assertions.assertThat(result.nickName).contains("멍멍이")
-        Assertions.assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.HAS_PET)
+        assertThat(result.nickName).contains("멍멍이")
+        assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.HAS_PET)
+        assertThat(result.signUpStatus).isEqualTo(SignUpStatus.COMPLETE)
     }
 
     @DisplayName("반려견 미보유 상태로 설정한다")
     @Test
-    fun setNoPetOwnership() {
+    fun registerWithoutPet() {
         // given
         val user = User.fixture(
             id = "test",
             petName = null,
             petOwnershipStatus = PetOwnershipStatus.UNKNOWN,
+            signUpStatus = SignUpStatus.IN_PROGRESS
         )
 
         // when
-        val result = userService.setNoPetOwnership(user)
+        val result = userService.registerWithoutPet(user)
 
         // then
-        Assertions.assertThat(result.nickName).isNotBlank()
-        Assertions.assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.NO_PET)
+        assertThat(result.nickName).isNotBlank()
+        assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.NO_PET)
+        assertThat(result.signUpStatus).isEqualTo(SignUpStatus.COMPLETE)
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
@@ -5,7 +5,7 @@ import nmnb.application.domain.user.service.dto.request.UserPetRegistrationReque
 import nmnb.domain.user.PetOwnershipStatus
 import nmnb.domain.user.SignUpStatus
 import nmnb.domain.user.User
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,7 +30,6 @@ class UserServiceImplTest(
         assertThat(result.nickName).isEqualTo(user.nickName)
         assertThat(result.profileImage).isEqualTo(user.profileImage)
         assertThat(result.petOwnershipStatus).isEqualTo(user.petOwnershipStatus)
-
     }
 
     @DisplayName("반려견의 이름을 등록하고 반려견 소유 상태를 설정한다")
@@ -41,7 +40,7 @@ class UserServiceImplTest(
             id = "test",
             petName = null,
             petOwnershipStatus = PetOwnershipStatus.UNKNOWN,
-            signUpStatus = SignUpStatus.IN_PROGRESS
+            signUpStatus = SignUpStatus.IN_PROGRESS,
         )
 
         val request = UserPetRegistrationRequest(petName = "멍멍이")
@@ -63,7 +62,7 @@ class UserServiceImplTest(
             id = "test",
             petName = null,
             petOwnershipStatus = PetOwnershipStatus.UNKNOWN,
-            signUpStatus = SignUpStatus.IN_PROGRESS
+            signUpStatus = SignUpStatus.IN_PROGRESS,
         )
 
         // when

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
@@ -28,7 +28,7 @@ class UserServiceImplTest(
         // then
         Assertions.assertThat(result.nickName).isEqualTo(user.nickName)
         Assertions.assertThat(result.profileImage).isEqualTo(user.profileImage)
-        Assertions.assertThat(result.hasAnimal).isEqualTo(user.hasAnimal)
+        Assertions.assertThat(result.petOwnershipStatus).isEqualTo(user.petOwnershipStatus)
     }
 
     @DisplayName("반려견을 등록한다")
@@ -48,6 +48,6 @@ class UserServiceImplTest(
 
         // then
         Assertions.assertThat(result.petName).isEqualTo("멍멍이")
-        Assertions.assertThat(result.hasAnimal).isEqualTo(true)
+        Assertions.assertThat(result.petOwnershipStatus).isEqualTo(PetOwnershipStatus.HAS_PET)
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/user/service/UserServiceImplTest.kt
@@ -38,7 +38,7 @@ class UserServiceImplTest(
         val user = User.fixture(
             id = "test",
             petName = null,
-            petOwnershipStatus = PetOwnershipStatus.NO_PET,
+            petOwnershipStatus = PetOwnershipStatus.UNKNOWN,
         )
 
         val request = UserPetRegistrationRequest(petName = "멍멍이")

--- a/nmnb-application/src/test/kotlin/nmnb/application/global/auth/service/AuthServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/global/auth/service/AuthServiceImplTest.kt
@@ -6,6 +6,7 @@ import nmnb.application.global.auth.service.dto.KakaoProfile
 import nmnb.application.global.infrastructure.oauth.KakaoOAuthClient
 import nmnb.application.global.infrastructure.oauth.OAuthClientComposite
 import nmnb.domain.auth.SocialType
+import nmnb.domain.user.SignUpStatus
 import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -80,5 +81,6 @@ class AuthServiceImplTest : IntegrationTestSupport() {
         assertThat(result.email).isEqualTo("test@example.com")
         assertThat(result.accessToken).isNotBlank()
         assertThat(result.refreshToken).isNotBlank()
+        assertThat(result.signUpStatus).isEqualTo(SignUpStatus.IN_PROGRESS)
     }
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/PetOwnershipStatus.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/PetOwnershipStatus.kt
@@ -1,6 +1,7 @@
 package nmnb.domain.user
 
 enum class PetOwnershipStatus {
+    UNKNOWN,
     HAS_PET,
     NO_PET,
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/SignUpStatus.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/SignUpStatus.kt
@@ -2,5 +2,5 @@ package nmnb.domain.user
 
 enum class SignUpStatus {
     IN_PROGRESS,
-    COMPLETE
+    COMPLETE,
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/SignUpStatus.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/SignUpStatus.kt
@@ -1,0 +1,6 @@
+package nmnb.domain.user
+
+enum class SignUpStatus {
+    IN_PROGRESS,
+    COMPLETE
+}

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import nmnb.domain.BaseEntity
 import nmnb.domain.post.Post
+import java.util.UUID
 
 @Entity
 @Table(name = "users")
@@ -42,7 +43,7 @@ class User(
 
         fun fixture(
             id: String? = null,
-            email: String = "ex@example.com",
+            email: String = "${UUID.randomUUID()}@example.com",
             profileImage: String = "default.png",
             petName: String? = null,
             petOwnershipStatus: PetOwnershipStatus = PetOwnershipStatus.NO_PET,

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
@@ -33,6 +33,9 @@ class User(
     @Enumerated(EnumType.STRING)
     var petOwnershipStatus: PetOwnershipStatus = PetOwnershipStatus.UNKNOWN
 
+    @Enumerated(EnumType.STRING)
+    var signUpStatus: SignUpStatus = SignUpStatus.IN_PROGRESS
+
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     var posts: MutableList<Post> = mutableListOf()
 
@@ -47,6 +50,7 @@ class User(
             profileImage: String = "default.png",
             petName: String? = null,
             petOwnershipStatus: PetOwnershipStatus = PetOwnershipStatus.NO_PET,
+            signUpStatus: SignUpStatus = SignUpStatus.COMPLETE,
             posts: MutableList<Post> = mutableListOf(),
         ): User {
             val user = User(
@@ -56,6 +60,7 @@ class User(
             )
             user.id = id
             user.petOwnershipStatus = petOwnershipStatus
+            user.signUpStatus = signUpStatus
             user.posts = posts
             return user
         }
@@ -67,5 +72,9 @@ class User(
 
     fun updatePetOwnershipStatus(status: PetOwnershipStatus) {
         this.petOwnershipStatus = status
+    }
+
+    fun updateSignUpStatus(status: SignUpStatus) {
+        this.signUpStatus = status
     }
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
@@ -30,7 +30,7 @@ class User(
     var id: String? = null
 
     @Enumerated(EnumType.STRING)
-    var petOwnershipStatus: PetOwnershipStatus = PetOwnershipStatus.NO_PET
+    var petOwnershipStatus: PetOwnershipStatus = PetOwnershipStatus.UNKNOWN
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     var posts: MutableList<Post> = mutableListOf()

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/user/User.kt
@@ -37,8 +37,6 @@ class User(
 
     val nickName: String
         get() = petName?.let { petName -> "$petName-$id" } ?: id.toString()
-    val hasAnimal: Boolean
-        get() = petOwnershipStatus == PetOwnershipStatus.HAS_PET
 
     companion object {
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #28 

## 📌 개요
- 회원가입 상태를 나타내는 `SignUpStatus`를 추가했습니다.
- PetOwnershipStatus enum에서 UNKNOWN 필드를 추가해주었습니다.
  - 소셜 로그인 된 상태가`NO_PET` 상태를 의미하는 것은 아니므로 (아직 어떻게 될지 모름)
      - 디폴트값은 `UNKNOWN`
      - 반려동물 등록하겠다 하면 `HAS_PET`
      - 반려동물 등록하지 않겠다 하면 `NO_PET`


  <img src="https://github.com/user-attachments/assets/be638a23-f78b-4ca7-84e5-aff7c32d473b" width=300 />

- 전체 테스트를 돌렸을 때, fixture에서 User의 email을 모두 ex@example.com으로 설정해서 다음과 같은 오류 발생
```
Unique index or primary key violation: 
"PUBLIC.CONSTRAINT_INDEX_4 ON PUBLIC.USERS(EMAIL NULLS FIRST) VALUES ('ex@example.com')"
```
- 즉, 테스트에서 User.fixture(...)로 만든 user의 email이 같은 값이라 DB에 여러 번 insert 되면서 충돌이 납니다. => 따라서 UUID로 랜덤 생성되도록 설정했습니다 : 45faae8bc0107b688ae30b4bf1359de84d961270

- 테스트 시에는 tignUpstatus가 COMPLETE인 경우가 대다수일 것이므로 fixture에는 COMPLETE를 디폴트값으로 설정했습니다.

<img src="https://github.com/user-attachments/assets/4c6c2aca-f3a6-4643-9e8d-b2639a4ac665" width = 300/>

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
