### PR TITLE
[fix] 비디오 다운로드 경로 버그 수정 및 스웨거 문서 개선

### DIFF
--- a/nmnb-common/src/main/kotlin/nmnb/common/response/status/ErrorStatus.kt
+++ b/nmnb-common/src/main/kotlin/nmnb/common/response/status/ErrorStatus.kt
@@ -28,7 +28,7 @@ enum class ErrorStatus(
     // POST
     POST_NOTFOUND(HttpStatus.NOT_FOUND, "POST400", "게시물을 찾을 수 없습니다."),
     POST_THUMBNAIL_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "POST500", "영상 썸네일 생성 중 오류가 발생했습니다."),
-    POST_S3_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "POST500", "S3에서 영상을 다운로드하는 데 실패했습니다"),
+    POST_S3_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "POST501", "S3에서 영상을 다운로드하는 데 실패했습니다"),
 
     // USER
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER400", "사용자를 찾을 수 없습니다."),

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
@@ -11,6 +11,7 @@ import nmnb.common.response.status.SuccessStatus
 import nmnb.r2dbc.user.R2dbcUser
 import nmnb.webflux.domain.post.controller.dto.request.PostInfoRequest
 import nmnb.webflux.domain.post.service.PostUploadService
+import nmnb.webflux.global.auth.generator.annotation.TokenApiResponse
 import nmnb.webflux.global.handler.annotation.AuthUser
 import org.springframework.http.MediaType
 import org.springframework.http.codec.multipart.FilePart
@@ -30,6 +31,7 @@ class PostController(
     @ApiResponses(
         ApiResponse(responseCode = "COMMON202", description = "요청 성공 및 반환할 콘텐츠가 없음."),
     )
+    @TokenApiResponse
     @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     suspend fun uploadPost(
         @Parameter(name = "user", hidden = true) @AuthUser user: R2dbcUser,

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
@@ -38,6 +38,16 @@ class PostController(
     suspend fun uploadPost(
         @Parameter(name = "user", hidden = true) @AuthUser user: R2dbcUser,
         @RequestPart(value = "file") file: FilePart,
+        @Parameter(
+            description = """ 
+        아래와 같은 JSON 형태로 입력해야 합니다:
+
+        {
+            "description": "강아지 영상입니다.",
+            "duration": 120
+        }
+    """
+        )
         @RequestPart("request") request: String,
     ): BaseResponse<Any> {
         val postInfo = objectMapper.readValue(request, PostInfoRequest::class.java)

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
@@ -30,6 +30,8 @@ class PostController(
     @Operation(summary = "영상 업로드 API", description = "영상을 업로드 합니다._숙희")
     @ApiResponses(
         ApiResponse(responseCode = "COMMON202", description = "요청 성공 및 반환할 콘텐츠가 없음."),
+        ApiResponse(responseCode = "POST500", description = "영상 썸네일 생성 중 오류가 발생했습니다."),
+        ApiResponse(responseCode = "POST501", description = "S3에서 영상을 다운로드하는 데 실패했습니다"),
     )
     @TokenApiResponse
     @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/auth/generator/annotation/TokenApiResponse.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/auth/generator/annotation/TokenApiResponse.kt
@@ -1,0 +1,16 @@
+package nmnb.webflux.global.auth.generator.annotation
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@ApiResponses(
+    ApiResponse(responseCode = "AUTH402", description = "잘못된 토큰 정보입니다."),
+    ApiResponse(responseCode = "AUTH403", description = "만료된 토큰입니다."),
+    ApiResponse(responseCode = "AUTH404", description = "지원하지 않는 토큰입니다."),
+    ApiResponse(responseCode = "AUTH405", description = "토큰이 요청에 포함되어 있지 않습니다."),
+    ApiResponse(responseCode = "AUTH406", description = "빈 토큰이 전달되었습니다."),
+    ApiResponse(responseCode = "AUTH407", description = "토큰에 이메일 정보가 없습니다."),
+)
+annotation class TokenApiResponse

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/s3/S3Service.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/s3/S3Service.kt
@@ -47,7 +47,7 @@ class S3Service(
         try {
             val request = GetObjectRequest.builder()
                 .bucket(s3Properties.s3.bucket)
-                .key(fileName)
+                .key(generateS3Key(VIDEO_FOLDER, fileName))
                 .build()
 
             s3AsyncClient.getObject(request, AsyncResponseTransformer.toFile(tempFile.toPath())).await()


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #48 

## 📌 개요
- 이전 브랜치와 관련이 높은 내용이므로 브랜치명을 그대로 사용했습니다.
- 비디오 다운로드 시 S3Key를 잘못 인식하는 문제가 있어 폴더명(video)을 지정하여 비디오 파일을 가져오도록 수정했습니다.
- 스웨거 문서에서 ErrorCode, 인증 실패 시 API 리스폰스, request에 대한 description을 작성했습니다.

## 🔁 변경 사항

## 📸 스크린샷
아래와 같이 description이 나타나게 됩니다.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e44944a3-deb1-4417-b74d-6e9b6a62bcbd" />


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
