### PR TITLE
[hotfix] 이미지 pull 방식으로 변경하여 이전 이미지가 build되는 문제 해결

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,9 +1,7 @@
 services:
   # MVC
   nmnb-blue:
-    build:
-      context: .
-      dockerfile: nmnb-bootstrap/Dockerfile
+    image: nmnb/nmnb:prod-mvc
     container_name: nmnb-blue
     environment:
       - SERVER_PORT=${nmnb_BLUE_PORT}
@@ -21,9 +19,7 @@ services:
       - nmnb_network
 
   nmnb-green:
-    build:
-      context: .
-      dockerfile: nmnb-bootstrap/Dockerfile
+    image: nmnb/nmnb:prod-mvc
     container_name: nmnb-green
     environment:
       - SERVER_PORT=${nmnb_GREEN_PORT}
@@ -41,9 +37,7 @@ services:
       - nmnb_network
 
   dev-nmnb:
-    build:
-      context: .
-      dockerfile: nmnb-bootstrap/Dockerfile
+    image: nmnb/nmnb:dev-mvc
     container_name: dev-nmnb
     environment:
       - SERVER_PORT=${nmnb_DEV_PORT}
@@ -62,9 +56,7 @@ services:
 
   # WebFlux
   nmnb-webflux-blue:
-    build:
-      context: .
-      dockerfile: nmnb-webflux-bootstrap/Dockerfile
+    image: nmnb/nmnb:prod-webflux
     container_name: nmnb-webflux-blue
     environment:
       - SERVER_PORT=${nmnb_WEBFLUX_BLUE_PORT}
@@ -82,9 +74,7 @@ services:
       - nmnb_network
 
   nmnb-webflux-green:
-    build:
-      context: .
-      dockerfile: nmnb-webflux-bootstrap/Dockerfile
+    image: nmnb/nmnb:prod-webflux
     container_name: nmnb-webflux-green
     environment:
       - SERVER_PORT=${nmnb_WEBFLUX_GREEN_PORT}
@@ -102,9 +92,7 @@ services:
       - nmnb_network
 
   dev-nmnb-webflux:
-    build:
-      context: .
-      dockerfile: nmnb-webflux-bootstrap/Dockerfile
+    image: nmnb/nmnb:dev-webflux
     container_name: dev-nmnb-webflux
     environment:
       - SERVER_PORT=${nmnb_WEBFLUX_DEV_PORT}

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/domain/post/controller/PostController.kt
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @Tag(name = "Post 🎞️", description = "영상 관련 API")
-@RequestMapping("/v1/api")
+@RequestMapping("/netty/v1/api")
 class PostController(
     private val objectMapper: ObjectMapper,
     private val postUploadService: PostUploadService,

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/config/SecurityConfig.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/config/SecurityConfig.kt
@@ -24,7 +24,7 @@ class SecurityConfig(
     )
 
     private val userUrl = arrayOf(
-        "/v1/api/upload",
+        "/netty/v1/api/upload",
     )
 
     @Bean

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -22,6 +22,19 @@ echo ".env 파일 복사 완료"
 echo "-----------------------------"
 echo
 
+set -o allexport
+source "$PROJECT_DIR/.dev_env"
+set +o allexport
+
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker 데몬이 실행 중인지 확인하세요."
+  exit 1
+fi
+
+echo "Docker Hub 로그인 중..."
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || { echo "Docker 로그인 실패"; exit 1; }
+echo "Docker 로그인 완료"
+
 echo "기존 컨테이너 중단 중..."
 sudo docker-compose --env-file "$PROJECT_DIR/.dev_env" -f "$COMPOSE_PATH" stop $MVC_API_ENV $WEBFLUX_API_ENV  || { echo "이전 환경 중지 실패"; exit 1; }
 
@@ -29,16 +42,8 @@ echo "기존 컨테이너 삭제 중..."
 sudo docker-compose --env-file "$PROJECT_DIR/.dev_env" -f "$COMPOSE_PATH" rm -f $MVC_API_ENV $WEBFLUX_API_ENV  || { echo "이전 환경 삭제 실패"; exit 1; }
 echo
 echo "-----------------------------"
-echo "도커 허브에서 새로운 이미지 pull 중: $MVC_API_ENV"
-sudo docker-compose --env-file "$PROJECT_DIR/.dev_env" -f "$COMPOSE_PATH" pull $MVC_API_ENV || { echo "이미지 pull 실패"; exit 1; }
-echo "이미지 pull 완료"
-echo "-----------------------------"
-echo
-
-echo
-echo "-----------------------------"
-echo "도커 허브에서 새로운 이미지 pull 중(webflux): $WEBFLUX_API_ENV"
-sudo docker-compose --env-file "$PROJECT_DIR/.dev_env" -f "$COMPOSE_PATH" pull $WEBFLUX_API_ENV || { echo "이미지 pull 실패"; exit 1; }
+echo "도커 허브에서 새로운 이미지 pull 중:"
+docker-compose --env-file "$PROJECT_DIR/.dev_env" -f "$COMPOSE_PATH" pull $MVC_API_ENV $WEBFLUX_API_ENV || { echo "이미지 pull 실패"; exit 1; }
 echo "이미지 pull 완료"
 echo "-----------------------------"
 echo

--- a/scripts/prod-deploy.sh
+++ b/scripts/prod-deploy.sh
@@ -60,10 +60,23 @@ echo ".env 파일 복사 완료"
 echo "-----------------------------"
 echo
 
-echo
+set -o allexport
+source "$PROJECT_DIR/.prod_env"
+set +o allexport
+
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker 데몬이 실행 중인지 확인하세요."
+  exit 1
+fi
+
+echo "Docker Hub 로그인 중..."
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || { echo "Docker 로그인 실패"; exit 1; }
+echo "Docker 로그인 완료"
+
+
 echo "-----------------------------"
-echo "도커 허브에서 새로운 이미지 pull 중: $NEW_API_ENV"
-sudo docker-compose -f "$COMPOSE_PATH" --env-file "$PROJECT_DIR/.prod_env" pull "$NEW_API_ENV" || { echo "이미지 pull 실패"; exit 1; }
+echo "도커 허브에서 새로운 이미지 pull 중:"
+docker-compose --env-file "$PROJECT_DIR/.prod_env" -f "$COMPOSE_PATH" pull $NEW_API_ENV $NEW_WEBFLUX_API_ENV || { echo "이미지 pull 실패"; exit 1; }
 echo "이미지 pull 완료"
 echo "-----------------------------"
 echo
@@ -78,14 +91,6 @@ if ! docker ps --filter "name=$NEW_API_ENV" --filter "status=running" | grep -q 
     echo "새로운 환경($NEW_API_ENV) 컨테이너가 정상 실행되지 않음"
     exit 1
 fi
-
-echo
-echo "-----------------------------"
-echo "도커 허브에서 새로운 이미지 pull 중(webflux): $NEW_WEBFLUX_API_ENV"
-sudo docker-compose -f "$COMPOSE_PATH" --env-file "$PROJECT_DIR/.prod_env" pull "$NEW_WEBFLUX_API_ENV" || { echo "이미지 pull 실패"; exit 1; }
-echo "이미지 pull 완료"
-echo "-----------------------------"
-echo
 
 echo "새로운 환경 시작 중(WEBFLUX): $NEW_WEBFLUX_API_ENV"
 sudo docker-compose -f "$COMPOSE_PATH" --env-file "$PROJECT_DIR/.prod_env" up -d --no-deps "$NEW_WEBFLUX_API_ENV" || { echo "새로운 환경 시작 실패(WEBFLUX)"; exit 1; }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #58

## 📌 개요
docker hub 에 **로그인해서 이미지 pull 받아오는 방식으로 수정**했습니다!

기존에는 아래 코드와 같이 docker-compose가 구성되어 있었기 때문에 이미지를 Docker Hub에서 가져오는 것이 아니라 로컬의 Dockerfile을 기반으로 직접 빌드하여 컨테이너를 생성하는 방식이었습니다.
```
 build:
      context: .
      dockerfile: nmnb-bootstrap/Dockerfile
```

이를 이미지 이름을 명시하여 Docker Hub에서 이미지를 받아오도록 수정했습니다.

이미지를 동시에 pull하도록 명령어를 작성했는데, 따로 작성하니 pull access deny가 떠서 **동시에 pull받도록 설정**해두었습니다. 

![image](https://github.com/user-attachments/assets/05b8e2db-5db5-4ed6-b002-deb2f1bb588e)
위 이미지와 같이 태그가 설정되어있습니다 도커 허브에서도 확인가능해용

+)  webflux 모듈 proxy 적용이 제대로 되지 않아 경로 수정했습니다. https://github.com/NMYB-Team/NMYB-Backend/pull/61


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
