### PR TITLE
[fix] Swagger 공통 관리 적용 및 경로 필터 예외 처리 로직 추가

### DIFF
--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/config/SecurityConfig.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package nmnb.webflux.global.config
 
 import nmnb.webflux.global.infrastructure.security.DeviceValidationFilter
 import nmnb.webflux.global.infrastructure.security.JWTFilter
+import nmnb.webflux.global.utils.SecurityConstants
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
@@ -17,14 +18,6 @@ class SecurityConfig(
     private val jwtFilter: JWTFilter,
     private val deviceValidationFilter: DeviceValidationFilter,
 ) {
-
-    private val allowedUrl = arrayOf(
-        "/netty/health",
-        "/netty/webjars/swagger-ui/**",
-        "/netty/swagger-ui.html/**",
-        "/netty/v3/api-docs/**",
-    )
-
     private val userUrl = arrayOf(
         "/netty/v1/api/upload",
     )
@@ -40,7 +33,7 @@ class SecurityConfig(
             .securityContextRepository(WebSessionServerSecurityContextRepository())
 
         http.authorizeExchange {
-            it.pathMatchers(*allowedUrl).permitAll()
+            it.pathMatchers(*SecurityConstants.SWAGGER_PATHS.map { path -> "$path/**" }.toTypedArray()).permitAll()
                 .pathMatchers(*userUrl)
                 .hasRole("USER")
                 .anyExchange().authenticated()

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/DeviceValidationFilter.kt
@@ -5,6 +5,7 @@ import nmnb.common.response.exception.GeneralException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.common.utils.HeaderConstants.DEVICE_ID_HEADER
+import nmnb.webflux.global.utils.SecurityConstants
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
@@ -15,7 +16,16 @@ import reactor.core.publisher.Mono
 class DeviceValidationFilter(
     private val jwtProvider: JwtProvider,
 ) : WebFilter {
+
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        val path = exchange.request.path.value()
+        if (SecurityConstants.SWAGGER_PATHS.any { swaggerPath ->
+                path == swaggerPath || path.startsWith("$swaggerPath/")
+            }
+        ) {
+            return chain.filter(exchange)
+        }
+
         val accessToken = exchange.request.headers.getFirst(ACCESS_TOKEN_HEADER)
 
         if (accessToken != null) {

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/utils/SecurityConstants.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/utils/SecurityConstants.kt
@@ -1,0 +1,10 @@
+package nmnb.webflux.global.utils
+
+object SecurityConstants {
+    val SWAGGER_PATHS = arrayOf(
+        "/netty/health",
+        "/netty/webjars/swagger-ui",
+        "/netty/swagger-ui.html",
+        "/netty/v3/api-docs",
+    )
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #72

## 📌 개요
[예외 로그]
```
nmnb.common.response.exception.GeneralException: null
        at nmnb.webflux.global.infrastructure.security.DeviceValidationFilter.filter(DeviceValidationFilter.kt:36) ~[nmnb-webflux-0.0.1-SNAPSHOT-plain.jar!/:na]
```
- DeviceValidationFilter에서 무조건 deviceId가 입력되어야하는 조건이 있어 swagger 접속시에도 500에러가 발생했었습니다. 
이를 해결하기 위해 DeviceValidationFilter에서 swagger 관련 경로는 필터를 적용하지 않도록 수정했고, 
경로가 중복된 부분들을 SWAGGER_PATHS로 분리하여 관리하도록 했습니다. 


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
