### PR TITLE
[fix] 로그인 경로 수정 및 응답 파싱 오류 해결을 위한 메시지 컨버터 등록

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/global/config/RestTemplateConfig.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/config/RestTemplateConfig.kt
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.converter.FormHttpMessageConverter
 import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.converter.StringHttpMessageConverter
 import org.springframework.web.client.RestTemplate
 
 @Configuration
@@ -14,6 +15,7 @@ class RestTemplateConfig {
 
         val messageConverters: MutableList<HttpMessageConverter<*>> = ArrayList()
         messageConverters.add(FormHttpMessageConverter())
+        messageConverters.add(StringHttpMessageConverter())
         restTemplate.messageConverters = messageConverters
 
         return restTemplate

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/config/SecurityConfig.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/config/SecurityConfig.kt
@@ -22,7 +22,7 @@ class SecurityConfig(
         "/swagger-ui/**",
         "/v3/api-docs/**",
         "/api/login",
-        "/v1/api/auth/login",
+        "/v1/api/auth/login/**",
         "/v1/api/videos",
     )
     private val userUrl = arrayOf(

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/external/oauth/BaseOAuthClient.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/external/oauth/BaseOAuthClient.kt
@@ -4,13 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import nmnb.common.response.exception.AuthException
 import nmnb.common.response.status.ErrorStatus
-import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
 
 abstract class BaseOAuthClient(
@@ -35,7 +33,7 @@ abstract class BaseOAuthClient(
 
     protected fun requestGet(accessToken: String, url: String): String {
         val headers = defaultHeaders().apply {
-            set(ACCESS_TOKEN_HEADER, accessToken)
+            setBearerAuth(accessToken)
         }
         val request = HttpEntity<MultiValueMap<String, String>>(headers)
         val response = restTemplate.exchange(

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/external/oauth/BaseOAuthClient.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/external/oauth/BaseOAuthClient.kt
@@ -35,7 +35,7 @@ abstract class BaseOAuthClient(
         val headers = defaultHeaders().apply {
             setBearerAuth(accessToken)
         }
-        val request = HttpEntity<MultiValueMap<String, String>>(headers)
+        val request = HttpEntity<Any>(headers)
         val response = restTemplate.exchange(
             url,
             HttpMethod.GET,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #74

## 📌 개요
**1. 403 예외** 
기존 `SecurityConfig`에 변경된 API 경로에 대한 허용 설정이 제대로 반영되어있지 않아 예외가 발생했습니다. 
수정했는데도 문제가 지속되어 로그 찍어 확인해보니 다음과 같이 헤더가 전송되고 있었습니다. 
```
"Content-Type:"application/x-www-form-urlencoded", X-Access-Token:"token
```
제가 이전에 accessToken 헤더명을 바꾸면서 여기도 수정했었는데 , 카카오에 날릴 때는 Authorization: Bearer <token> 형식을 지켜야한다고 하네요🥹 이 부분 다시 수정해두었습니다!

**2. HttpMessageConverter 예외**
```
"Could not extract response: no suitable HttpMessageConverter found for response type [class java.lang.String] and content type [application/json;charset=UTF-8]"
```
해당 예외가 발생했고, RestTemplate에 등록된 Converter를 살펴보니 FormHttpMessageConverter만 등록되어있는 것을 확인했습니다. 
String 타입을 받기 위해서는 `StringHttpMessageConverter`가 필요했고 config파일에 등록해 문제를 해결했습니다.

**3.** 
GET 요청시 본문 없이 헤더만 전달하는것이 REST 표준에 맞으므로  `HttpEntity<MultiValueMap<String, String>>(headers)`에서 `HttpEntity<Any>`로 수정하였습니다. 


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
