### PR TITLE
[fix] 액세스 토큰 예외 처리 추가

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/user/controller/UserController.kt
@@ -48,6 +48,7 @@ class UserController(
         ApiResponse(responseCode = "PET402", description = "반려동물 상태 값이 유효하지 않습니다."),
         ApiResponse(responseCode = "USER500", description = "프로필 이미지 업로드 중 오류가 발생했습니다."),
     )
+    @TokenApiResponse
     @PostMapping("/profile", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun editProfile(
         @Parameter(name = "user", hidden = true) @AuthUser user: User,
@@ -93,6 +94,7 @@ class UserController(
         description = "가입하는 유저가 반려견을 보유하지 않았음을 설정합니다. petOwnershipStatus가 NO_PET으로 설정됩니다._예림",
     )
     @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
+    @TokenApiResponse
     @PatchMapping("/pet/none")
     fun registerWithoutPet(
         @Parameter(

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/common/utils/ResponseUtils.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/common/utils/ResponseUtils.kt
@@ -1,4 +1,4 @@
-package nmnb.common.utils
+package nmnb.application.global.common.utils
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletResponse

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
@@ -7,7 +7,7 @@ import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.common.utils.HeaderConstants.DEVICE_ID_HEADER
 import nmnb.common.utils.JwtConstants.DEVICE_ID_CLAIM_KEY
-import nmnb.common.utils.ResponseUtils
+import nmnb.application.global.common.utils.ResponseUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
@@ -3,11 +3,12 @@ package nmnb.application.global.infrastructure.security
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import nmnb.application.global.common.utils.ResponseUtils
+import nmnb.common.response.exception.AuthException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.common.utils.HeaderConstants.DEVICE_ID_HEADER
 import nmnb.common.utils.JwtConstants.DEVICE_ID_CLAIM_KEY
-import nmnb.application.global.common.utils.ResponseUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
@@ -28,9 +29,11 @@ class DeviceValidationFilter(
                 val deviceIdInRequest = request.getHeader(DEVICE_ID_HEADER)
 
                 if (deviceIdInToken == null || deviceIdInRequest == null || deviceIdInToken != deviceIdInRequest) {
-                    responseUtils.sendErrorResponse(response, ErrorStatus.DEVICE_ID_MISMATCH.getReasonHttpStatus())
-                    return
+                    throw AuthException(ErrorStatus.DEVICE_ID_MISMATCH)
                 }
+            } catch (e: AuthException) {
+                responseUtils.sendErrorResponse(response, ErrorStatus.DEVICE_ID_MISMATCH.getReasonHttpStatus())
+                return
             } catch (e: Exception) {
                 responseUtils.sendErrorResponse(response, ErrorStatus.UNAUTHORIZED.getReasonHttpStatus())
                 return

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
@@ -1,8 +1,10 @@
 package nmnb.application.global.infrastructure.security
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import nmnb.common.response.base.BaseResponse
 import nmnb.common.response.exception.AuthException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
@@ -14,6 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class DeviceValidationFilter(
     private val jwtProvider: JwtProvider,
+    private val objectMapper: ObjectMapper,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -27,15 +30,28 @@ class DeviceValidationFilter(
                 val deviceIdInRequest = request.getHeader(DEVICE_ID_HEADER)
 
                 if (deviceIdInToken == null || deviceIdInRequest == null || deviceIdInToken != deviceIdInRequest) {
-                    throw AuthException(ErrorStatus.DEVICE_ID_MISMATCH)
+                    sendErrorResponse(response, ErrorStatus.DEVICE_ID_MISMATCH)
+                    return
                 }
-            } catch (e: AuthException) {
-                throw e
             } catch (e: Exception) {
-                throw AuthException(ErrorStatus.UNAUTHORIZED)
+                sendErrorResponse(response, ErrorStatus.UNAUTHORIZED)
+                return
             }
         }
 
         filterChain.doFilter(request, response)
+    }
+
+    private fun sendErrorResponse(response: HttpServletResponse, errorStatus: ErrorStatus) {
+        response.status = errorStatus.httpStatus!!.value()
+        response.contentType = "application/json;charset=UTF-8"
+
+        val errorBody = BaseResponse.onFailure(
+            errorStatus.code,
+            errorStatus.message,
+            null
+        )
+
+        response.writer.write(objectMapper.writeValueAsString(errorBody))
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
@@ -28,11 +28,13 @@ class DeviceValidationFilter(
                 val deviceIdInToken = jwtProvider.getClaimFromToken(accessToken, DEVICE_ID_CLAIM_KEY) as? String
                 val deviceIdInRequest = request.getHeader(DEVICE_ID_HEADER)
 
-                if (deviceIdInToken == null || deviceIdInRequest == null || deviceIdInToken != deviceIdInRequest) {
+                if (deviceIdInRequest == null) {
+                    throw AuthException(ErrorStatus.DEVICE_ID_MISSING)
+                } else if (deviceIdInToken == null || deviceIdInToken != deviceIdInRequest) {
                     throw AuthException(ErrorStatus.DEVICE_ID_MISMATCH)
                 }
             } catch (e: AuthException) {
-                responseUtils.sendErrorResponse(response, ErrorStatus.DEVICE_ID_MISMATCH.getReasonHttpStatus())
+                responseUtils.sendErrorResponse(response, e.getErrorReasonHttpStatus())
                 return
             } catch (e: Exception) {
                 responseUtils.sendErrorResponse(response, ErrorStatus.UNAUTHORIZED.getReasonHttpStatus())

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/DeviceValidationFilter.kt
@@ -1,22 +1,20 @@
 package nmnb.application.global.infrastructure.security
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import nmnb.common.response.base.BaseResponse
-import nmnb.common.response.exception.AuthException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.common.utils.HeaderConstants.DEVICE_ID_HEADER
 import nmnb.common.utils.JwtConstants.DEVICE_ID_CLAIM_KEY
+import nmnb.common.utils.ResponseUtils
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class DeviceValidationFilter(
     private val jwtProvider: JwtProvider,
-    private val objectMapper: ObjectMapper,
+    private val responseUtils: ResponseUtils,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -30,28 +28,15 @@ class DeviceValidationFilter(
                 val deviceIdInRequest = request.getHeader(DEVICE_ID_HEADER)
 
                 if (deviceIdInToken == null || deviceIdInRequest == null || deviceIdInToken != deviceIdInRequest) {
-                    sendErrorResponse(response, ErrorStatus.DEVICE_ID_MISMATCH)
+                    responseUtils.sendErrorResponse(response, ErrorStatus.DEVICE_ID_MISMATCH.getReasonHttpStatus())
                     return
                 }
             } catch (e: Exception) {
-                sendErrorResponse(response, ErrorStatus.UNAUTHORIZED)
+                responseUtils.sendErrorResponse(response, ErrorStatus.UNAUTHORIZED.getReasonHttpStatus())
                 return
             }
         }
 
         filterChain.doFilter(request, response)
-    }
-
-    private fun sendErrorResponse(response: HttpServletResponse, errorStatus: ErrorStatus) {
-        response.status = errorStatus.httpStatus!!.value()
-        response.contentType = "application/json;charset=UTF-8"
-
-        val errorBody = BaseResponse.onFailure(
-            errorStatus.code,
-            errorStatus.message,
-            null
-        )
-
-        response.writer.write(objectMapper.writeValueAsString(errorBody))
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
@@ -8,7 +8,7 @@ import nmnb.common.response.exception.AuthException
 import nmnb.common.response.exception.GeneralException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
-import nmnb.common.utils.ResponseUtils
+import nmnb.application.global.common.utils.ResponseUtils
 import nmnb.domain.user.repository.UserRepository
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
@@ -8,6 +8,7 @@ import nmnb.common.response.exception.AuthException
 import nmnb.common.response.exception.GeneralException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
+import nmnb.common.utils.ResponseUtils
 import nmnb.domain.user.repository.UserRepository
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
@@ -20,6 +21,7 @@ class JWTFilter(
     private val jwtProvider: JwtProvider,
     private val userRepository: UserRepository,
     private val blacklistService: BlacklistService,
+    private val responseUtils: ResponseUtils,
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -28,32 +30,38 @@ class JWTFilter(
         filterChain: FilterChain,
     ) {
         val accessToken = request.getHeader(ACCESS_TOKEN_HEADER)
-        if (accessToken != null) {
-            try {
-                if (blacklistService.isBlacklisted(accessToken)) {
-                    throw AuthException(ErrorStatus.TOKEN_LOGGED_OUT)
-                }
 
-                val email = jwtProvider.getEmailWithValidation(accessToken)
-                val user = userRepository.findByEmail(email)
-                    ?: throw AuthException(ErrorStatus.USER_NOT_FOUND)
+        if (accessToken == null) {
+            responseUtils.sendErrorResponse(response, ErrorStatus.AUTH_ACCESS_TOKEN_MISSING.getReasonHttpStatus())
+            return
+        }
 
-                val userDetails = CustomUserDetails(user)
-
-                val authentication = UsernamePasswordAuthenticationToken(
-                    userDetails,
-                    null,
-                    userDetails.authorities,
-                ).apply {
-                    details = WebAuthenticationDetailsSource().buildDetails(request)
-                }
-
-                SecurityContextHolder.getContext().authentication = authentication
-            } catch (e: AuthException) {
-                throw e
-            } catch (e: GeneralException) {
-                throw AuthException(ErrorStatus.UNAUTHORIZED)
+        try {
+            if (blacklistService.isBlacklisted(accessToken)) {
+                throw AuthException(ErrorStatus.TOKEN_LOGGED_OUT)
             }
+
+            val email = jwtProvider.getEmailWithValidation(accessToken)
+            val user = userRepository.findByEmail(email)
+                ?: throw AuthException(ErrorStatus.USER_NOT_FOUND)
+
+            val userDetails = CustomUserDetails(user)
+
+            val authentication = UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.authorities,
+            ).apply {
+                details = WebAuthenticationDetailsSource().buildDetails(request)
+            }
+
+            SecurityContextHolder.getContext().authentication = authentication
+        } catch (e: GeneralException) {
+            responseUtils.sendErrorResponse(response, e.getErrorReasonHttpStatus())
+            return
+        } catch (e: Exception) {
+            responseUtils.sendErrorResponse(response, ErrorStatus.UNAUTHORIZED.getReasonHttpStatus())
+            return
         }
 
         filterChain.doFilter(request, response)

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
@@ -31,37 +31,34 @@ class JWTFilter(
     ) {
         val accessToken = request.getHeader(ACCESS_TOKEN_HEADER)
 
-        if (accessToken == null) {
-            responseUtils.sendErrorResponse(response, ErrorStatus.AUTH_ACCESS_TOKEN_MISSING.getReasonHttpStatus())
-            return
-        }
+        if (accessToken != null) {
+            try {
+                if (blacklistService.isBlacklisted(accessToken)) {
+                    throw AuthException(ErrorStatus.TOKEN_LOGGED_OUT)
+                }
 
-        try {
-            if (blacklistService.isBlacklisted(accessToken)) {
-                throw AuthException(ErrorStatus.TOKEN_LOGGED_OUT)
+                val email = jwtProvider.getEmailWithValidation(accessToken)
+                val user = userRepository.findByEmail(email)
+                    ?: throw AuthException(ErrorStatus.USER_NOT_FOUND)
+
+                val userDetails = CustomUserDetails(user)
+
+                val authentication = UsernamePasswordAuthenticationToken(
+                    userDetails,
+                    null,
+                    userDetails.authorities,
+                ).apply {
+                    details = WebAuthenticationDetailsSource().buildDetails(request)
+                }
+
+                SecurityContextHolder.getContext().authentication = authentication
+            } catch (e: GeneralException) {
+                responseUtils.sendErrorResponse(response, e.getErrorReasonHttpStatus())
+                return
+            } catch (e: Exception) {
+                responseUtils.sendErrorResponse(response, ErrorStatus.UNAUTHORIZED.getReasonHttpStatus())
+                return
             }
-
-            val email = jwtProvider.getEmailWithValidation(accessToken)
-            val user = userRepository.findByEmail(email)
-                ?: throw AuthException(ErrorStatus.USER_NOT_FOUND)
-
-            val userDetails = CustomUserDetails(user)
-
-            val authentication = UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.authorities,
-            ).apply {
-                details = WebAuthenticationDetailsSource().buildDetails(request)
-            }
-
-            SecurityContextHolder.getContext().authentication = authentication
-        } catch (e: GeneralException) {
-            responseUtils.sendErrorResponse(response, e.getErrorReasonHttpStatus())
-            return
-        } catch (e: Exception) {
-            responseUtils.sendErrorResponse(response, ErrorStatus.UNAUTHORIZED.getReasonHttpStatus())
-            return
         }
 
         filterChain.doFilter(request, response)

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/infrastructure/security/JWTFilter.kt
@@ -4,11 +4,11 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import nmnb.application.global.auth.domain.CustomUserDetails
+import nmnb.application.global.common.utils.ResponseUtils
 import nmnb.common.response.exception.AuthException
 import nmnb.common.response.exception.GeneralException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
-import nmnb.application.global.common.utils.ResponseUtils
 import nmnb.domain.user.repository.UserRepository
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder

--- a/nmnb-common/src/main/kotlin/nmnb/common/utils/ResponseUtils.kt
+++ b/nmnb-common/src/main/kotlin/nmnb/common/utils/ResponseUtils.kt
@@ -1,0 +1,29 @@
+package nmnb.common.utils
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletResponse
+import nmnb.common.response.base.BaseResponse
+import nmnb.common.response.dto.ErrorReasonDTO
+import org.springframework.stereotype.Component
+
+@Component
+class ResponseUtils(
+    private val objectMapper: ObjectMapper,
+) {
+    fun sendErrorResponse(
+        response: HttpServletResponse,
+        errorReasonDTO: ErrorReasonDTO,
+    ) {
+        response.status = errorReasonDTO.httpStatus.value()
+        response.contentType = "application/json;charset=UTF-8"
+
+        val body = BaseResponse.onFailure(
+            errorReasonDTO.code,
+            errorReasonDTO.message,
+            null,
+        )
+
+        response.writer.write(objectMapper.writeValueAsString(body))
+        response.writer.flush()
+    }
+}

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/DeviceValidationFilter.kt
@@ -6,6 +6,7 @@ import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.common.utils.HeaderConstants.DEVICE_ID_HEADER
 import nmnb.common.utils.JwtConstants.DEVICE_ID_CLAIM_KEY
+import nmnb.webflux.global.utils.ResponseUtils
 import nmnb.webflux.global.utils.SecurityConstants
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
@@ -16,6 +17,7 @@ import reactor.core.publisher.Mono
 @Component
 class DeviceValidationFilter(
     private val jwtProvider: JwtProvider,
+    private val responseUtils: ResponseUtils,
 ) : WebFilter {
 
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
@@ -34,13 +36,29 @@ class DeviceValidationFilter(
                 val deviceIdInToken = jwtProvider.getClaimFromToken(accessToken, DEVICE_ID_CLAIM_KEY) as? String
                 val deviceIdInRequest = exchange.request.headers.getFirst(DEVICE_ID_HEADER)
 
-                if (deviceIdInToken == null || deviceIdInRequest == null || deviceIdInToken != deviceIdInRequest) {
-                    Mono.error(AuthException(ErrorStatus.DEVICE_ID_MISMATCH))
-                } else {
-                    chain.filter(exchange)
+                val validationMono = when {
+                    deviceIdInRequest == null ->
+                        Mono.error(AuthException(ErrorStatus.DEVICE_ID_MISSING))
+                    deviceIdInToken == null || deviceIdInToken != deviceIdInRequest ->
+                        Mono.error(AuthException(ErrorStatus.DEVICE_ID_MISMATCH))
+                    else ->
+                        chain.filter(exchange)
                 }
+
+                validationMono
             } catch (e: Exception) {
                 Mono.error(AuthException(ErrorStatus.UNAUTHORIZED))
+            }.onErrorResume { throwable ->
+                when (throwable) {
+                    is GeneralException -> responseUtils.sendErrorResponse(
+                        exchange,
+                        throwable.getErrorReasonHttpStatus(),
+                    )
+                    else -> responseUtils.sendErrorResponse(
+                        exchange,
+                        ErrorStatus.UNAUTHORIZED.getReasonHttpStatus(),
+                    )
+                }
             }
         }
 

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/JWTFilter.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/JWTFilter.kt
@@ -6,6 +6,7 @@ import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.r2dbc.user.R2dbcUserRepository
 import nmnb.webflux.global.auth.domain.CustomUserDetails
+import nmnb.webflux.global.utils.ResponseUtils
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.stereotype.Component
@@ -19,32 +20,50 @@ class JWTFilter(
     private val jwtProvider: JwtProvider,
     private val userRepository: R2dbcUserRepository,
     private val blacklistService: BlacklistService,
+    private val responseUtils: ResponseUtils,
 ) : WebFilter {
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
         val accessToken =
             exchange.request.headers.getFirst(ACCESS_TOKEN_HEADER) ?: return chain.filter(exchange)
-        if (!jwtProvider.isValidToken(accessToken)) return Mono.error(GeneralException(ErrorStatus.AUTH_INVALID_TOKEN))
 
-        return blacklistService.isBlacklisted(accessToken).flatMap { isBlacklisted ->
-            if (isBlacklisted) {
-                return@flatMap Mono.error(AuthException(ErrorStatus.TOKEN_LOGGED_OUT))
-            }
-            val username = jwtProvider.getEmail(accessToken)
+        return try {
+            if (!jwtProvider.isValidToken(accessToken)) return Mono.error(GeneralException(ErrorStatus.AUTH_INVALID_TOKEN))
 
-            return@flatMap userRepository.findByEmail(username)
-                .switchIfEmpty(Mono.error(GeneralException(ErrorStatus.USER_NOT_FOUND)))
-                .flatMap { user ->
-                    val userDetails = CustomUserDetails(user)
-
-                    val authenticationToken = UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.authorities,
-                    )
-
-                    chain.filter(exchange)
-                        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authenticationToken))
+            blacklistService.isBlacklisted(accessToken).flatMap { isBlacklisted ->
+                if (isBlacklisted) {
+                    return@flatMap Mono.error(AuthException(ErrorStatus.TOKEN_LOGGED_OUT))
                 }
+                val username = jwtProvider.getEmail(accessToken)
+
+                return@flatMap userRepository.findByEmail(username)
+                    .switchIfEmpty(Mono.error(GeneralException(ErrorStatus.USER_NOT_FOUND)))
+                    .flatMap { user ->
+                        val userDetails = CustomUserDetails(user)
+
+                        val authenticationToken = UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.authorities,
+                        )
+
+                        chain.filter(exchange)
+                            .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authenticationToken))
+                    }
+            }
+
+        } catch (e: Exception) {
+            Mono.error(e)
+        }.onErrorResume { throwable ->
+            when (throwable) {
+                is GeneralException -> responseUtils.sendErrorResponse(
+                    exchange,
+                    throwable.getErrorReasonHttpStatus()
+                )
+                else -> responseUtils.sendErrorResponse(
+                    exchange,
+                    ErrorStatus.UNAUTHORIZED.getReasonHttpStatus()
+                )
+            }
         }
     }
 }

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/utils/ResponseUtils.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/utils/ResponseUtils.kt
@@ -1,0 +1,35 @@
+package nmnb.webflux.global.utils
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import nmnb.common.response.base.BaseResponse
+import nmnb.common.response.dto.ErrorReasonDTO
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import reactor.core.publisher.Mono
+
+@Component
+class ResponseUtils(
+    private val objectMapper: ObjectMapper,
+) {
+    fun sendErrorResponse(
+        exchange: ServerWebExchange,
+        errorReasonDTO: ErrorReasonDTO,
+    ): Mono<Void> {
+        val response = exchange.response
+
+        response.statusCode = HttpStatus.valueOf(errorReasonDTO.httpStatus.value())
+        response.headers.add("Content-Type", "application/json;charset=UTF-8")
+
+        val body = BaseResponse.onFailure(
+            errorReasonDTO.code,
+            errorReasonDTO.message,
+            null,
+        )
+
+        val bodyJson = objectMapper.writeValueAsString(body)
+        val dataBuffer = response.bufferFactory().wrap(bodyJson.toByteArray())
+
+        return response.writeWith(Mono.just(dataBuffer))
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #76 

## 📌 개요
- `DeviceValidationFilter`에서 throw AuthException(...) 해도
  → 커스텀 예외 처리기가 잡지 못하고
  → Spring 기본 500 혹은 403 오류 페이지 혹은 응답 형식 없이 그대로 날아가는 문제 발생
- 이는 Filter는 DispatcherServlet 바깥에 있기 때문에, 예외가 DispatcherServlet으로 도달하지 않아서 생기는 문제이기 때문에 예외를 직접 처리해야 합니다. 따라서 직접 HttpServletResponse를 가공해서 BaseResponse 형태로 내려주도록 작성했습니다.
- 스프링 빈으로 주입받은 ObjectMapper를 사용하기 위해서 Util 클래스는 component로 등록했습니다.
  - 고민했던 사항 : 
  Object Mapper 사용 시
    -  jacksonObjectMapper()를 유틸 클래스에서 직접 만들지(간단하지만 스프링 설정 무시)
    - ResponseUtil을 Component 클래스로 등록하여 ObjectMapper를 빈 주입 받을지 고민하다가
  나중에 ObjectMapper를 설정할 수 있음을 고려하여 Component로 만들었습니다


- 디바이스 id가 null일 경우와 매치되지 않을 경우를 분기 처리했습니다.

## 🔁 변경 사항

## 📸 스크린샷
[톰캣 서버]
- 디바이스 id 미입력 시
  <img width="1389" height="274" alt="image" src="https://github.com/user-attachments/assets/d59a3b6c-441b-4039-a9a7-5bd02d4b552b" />
- 디바이스 id가 매치되지 않을 시
  <img width="1398" height="299" alt="image" src="https://github.com/user-attachments/assets/aad67a73-5140-4871-b37e-45f7c57f083c" />
- 잘못된 액세스 토큰 입력 시
  <img width="1402" height="298" alt="image" src="https://github.com/user-attachments/assets/4e45f2f5-0a76-4bb9-9706-68d306bc8e8e" />


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
