### PR TITLE
[refactor] JWT secret key 값 설정 오류 및 claim 내 deviceId 불일치 문제 해결

### DIFF
--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/DeviceValidationFilter.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/DeviceValidationFilter.kt
@@ -5,6 +5,7 @@ import nmnb.common.response.exception.GeneralException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.HeaderConstants.ACCESS_TOKEN_HEADER
 import nmnb.common.utils.HeaderConstants.DEVICE_ID_HEADER
+import nmnb.common.utils.JwtConstants.DEVICE_ID_CLAIM_KEY
 import nmnb.webflux.global.utils.SecurityConstants
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
@@ -30,7 +31,7 @@ class DeviceValidationFilter(
 
         if (accessToken != null) {
             return try {
-                val deviceIdInToken = jwtProvider.getClaimFromToken(accessToken, DEVICE_ID_HEADER) as? String
+                val deviceIdInToken = jwtProvider.getClaimFromToken(accessToken, DEVICE_ID_CLAIM_KEY) as? String
                 val deviceIdInRequest = exchange.request.headers.getFirst(DEVICE_ID_HEADER)
 
                 if (deviceIdInToken == null || deviceIdInRequest == null || deviceIdInToken != deviceIdInRequest) {

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/JwtProvider.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/JwtProvider.kt
@@ -2,18 +2,17 @@ package nmnb.webflux.global.infrastructure.security
 
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
-import io.jsonwebtoken.Jws
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
-import nmnb.common.response.exception.GeneralException
+import nmnb.common.response.exception.AuthException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.common.utils.JwtConstants.EMAIL_CLAIM_KEY
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import javax.crypto.SecretKey
+import java.security.SignatureException
 
 @Component
 class JwtProvider(
@@ -22,43 +21,36 @@ class JwtProvider(
     private val key by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret)) }
 
     fun isValidToken(token: String): Boolean {
-        return try {
-            val claims = getClaims(token)
-            val now = java.util.Date()
-            val expiredDate = claims.body.expiration
-            expiredDate.after(now)
-        } catch (e: ExpiredJwtException) {
-            throw GeneralException(ErrorStatus.AUTH_EXPIRED_TOKEN)
-        } catch (e: SecurityException) {
-            throw GeneralException(ErrorStatus.AUTH_INVALID_TOKEN)
-        } catch (e: MalformedJwtException) {
-            throw GeneralException(ErrorStatus.AUTH_INVALID_TOKEN)
-        } catch (e: IllegalArgumentException) {
-            throw GeneralException(ErrorStatus.AUTH_INVALID_TOKEN)
-        } catch (e: UnsupportedJwtException) {
-            throw GeneralException(ErrorStatus.UNSUPPORTED_TOKEN)
-        }
+        val claims = parseClaims(token)
+        val now = java.util.Date()
+        return claims.expiration.after(now)
     }
 
     fun getEmail(token: String): String {
-        return getClaims(token).body.get(EMAIL_CLAIM_KEY, String::class.java)
-    }
-
-    private fun getClaims(token: String): Jws<Claims> {
-        return Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token)
-    }
-
-    private fun getSigningKey(): SecretKey? {
-        val keyBytes = Decoders.BASE64.decode(secret)
-        return Keys.hmacShaKeyFor(keyBytes)
+        return parseClaims(token).get(EMAIL_CLAIM_KEY, String::class.java)
     }
 
     fun getClaimFromToken(token: String, claimKey: String): Any? {
-        val claims = Jwts.parserBuilder()
-            .setSigningKey(key)
-            .build()
-            .parseClaimsJws(token)
-            .body
+        val claims = parseClaims(token)
         return claims[claimKey]
+    }
+    private fun parseClaims(token: String): Claims {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
+        } catch (e: ExpiredJwtException) {
+            throw AuthException(ErrorStatus.AUTH_EXPIRED_TOKEN)
+        } catch (e: UnsupportedJwtException) {
+            throw AuthException(ErrorStatus.UNSUPPORTED_TOKEN)
+        } catch (e: MalformedJwtException) {
+            throw AuthException(ErrorStatus.AUTH_INVALID_TOKEN)
+        } catch (e: SignatureException) {
+            throw AuthException(ErrorStatus.AUTH_INVALID_TOKEN)
+        } catch (e: IllegalArgumentException) {
+            throw AuthException(ErrorStatus.AUTH_EMPTY_TOKEN)
+        }
     }
 }

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/JwtProvider.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/security/JwtProvider.kt
@@ -19,6 +19,8 @@ import javax.crypto.SecretKey
 class JwtProvider(
     @Value("\${jwt.secret}") private val secret: String,
 ) {
+    private val key by lazy { Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret)) }
+
     fun isValidToken(token: String): Boolean {
         return try {
             val claims = getClaims(token)
@@ -53,7 +55,7 @@ class JwtProvider(
 
     fun getClaimFromToken(token: String, claimKey: String): Any? {
         val claims = Jwts.parserBuilder()
-            .setSigningKey(token)
+            .setSigningKey(key)
             .build()
             .parseClaimsJws(token)
             .body


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #78 

## 📌 개요
- 영상 업로드 기능을 실행하니 내부적으로 `DeviceValidationFilter`가 돌면서 500예외가 발생했었습니다.   
확인해보니 JWT 파싱하면서 생긴 문제였고,  

1) claim key 값을 `DEVICE_ID_HEADER`  로 설정해두어 잘못된 key값으로 파싱하려고 해서 예외가 발생했고 이를  `DEVICE_ID_CLAIM_KEY`로 수정했습니다!

이 문제를 겪으면서 예외가 500으로만 나타나니 자세하게 어떤 문제인지 알기 쉽지 않아 jwt 파싱하는 과정에 예외처리를 추가해뒀고, 
해당 클래스에 중복되는 로직이 포함되어있어, 리팩토링 진행하였습니다. 

2) 파싱하는 과정에서 
```
 return Jwts.parserBuilder()
                .setSigningKey(token) // 이 부분
                .build()
                .parseClaimsJws(token)
                .body
```
다음과 같이 setSigningKey에 토큰을 넣어뒀더라구요!! 왜그랬지.. 싶었습니다. key로 변경해주었고, getSigningKey 메서드로 받아오던 key값을 applicaition 모듈 내의 로직과 동일하게 지연 로딩으로 설정하여 사용하는 방식으로 통일했습니다. 
-> 이전 방식보다 한번만 선언되고, secret이 동적으로 바뀌지 않기 때문에 해당방식 장점을 가진다고 생각했습니다!


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
