### PR TITLE
[refactor] 썸네일 생성 과정 에러 처리 및 리소스 관리 개선

### DIFF
--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/redis/ThumbnailWorker.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/redis/ThumbnailWorker.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.annotation.PostConstruct
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -55,16 +57,20 @@ class ThumbnailWorker(
         }
     }
 
-    private suspend fun processPayload(payload: String) {
+    private suspend fun processPayload(payload: String) = coroutineScope {
         val job = objectMapper.readValue(payload, ThumbnailJobPayload::class.java)
         val postId = job.postId
         val fileName = job.fileName
         val accessStrategy = job.accessStrategy
 
-        val localVideoFile = s3Service.download(fileName)
+        val downloadDeferred = async { s3Service.download(fileName) }
+        val thumbnailDeferred = async {
+            val localVideoFile = downloadDeferred.await()
+            ffmpegService.createThumbnail(localVideoFile)
+        }
 
-        val thumbnailFile = ffmpegService.createThumbnail(localVideoFile)
-
+        val localVideoFile = downloadDeferred.await()
+        val thumbnailFile = thumbnailDeferred.await()
         val thumbnailUrl = s3Service.uploadThumbnail(fileName, thumbnailFile, accessStrategy)
 
         val post = postRepository.findById(postId).awaitSingleOrNull()

--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/redis/ThumbnailWorker.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/redis/ThumbnailWorker.kt
@@ -18,6 +18,7 @@ import nmnb.webflux.global.infrastructure.external.s3.S3Service
 import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.stereotype.Component
+import java.io.File
 
 @Component
 class ThumbnailWorker(
@@ -63,24 +64,34 @@ class ThumbnailWorker(
         val fileName = job.fileName
         val accessStrategy = job.accessStrategy
 
-        val downloadDeferred = async { s3Service.download(fileName) }
-        val thumbnailDeferred = async {
-            val localVideoFile = downloadDeferred.await()
-            ffmpegService.createThumbnail(localVideoFile)
-        }
-
-        val localVideoFile = downloadDeferred.await()
-        val thumbnailFile = thumbnailDeferred.await()
+        val thumbnailFile = createThumbnail(fileName)
         val thumbnailUrl = s3Service.uploadThumbnail(fileName, thumbnailFile, accessStrategy)
 
+        updatePostThumbnail(postId, thumbnailUrl)
+
+        thumbnailFile.delete()
+    }
+
+    private suspend fun createThumbnail(fileName: String): File =
+        coroutineScope {
+            val videoDownload = async { s3Service.download(fileName) }
+            val thumbnailGeneration = async {
+                val localVideoFile = videoDownload.await()
+                ffmpegService.createThumbnail(localVideoFile)
+            }
+
+            val thumbnailFile = thumbnailGeneration.await()
+
+            thumbnailFile
+    }
+
+
+    private suspend fun updatePostThumbnail(postId: Long, thumbnailUrl: String) {
         val post = postRepository.findById(postId).awaitSingleOrNull()
         post?.let {
             val updated = it.updateThumbnail(thumbnailUrl)
             postRepository.save(updated).awaitSingle()
         }
-
-        localVideoFile.delete()
-        thumbnailFile.delete()
     }
 
     companion object {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #65 

## 📌 개요
~~processPayload 함수의 구조를 리팩토링하고, 비디오 생성을 병렬처리 방식으로 변경했습니다.~~
기존 비디오 처리 로직에서 다음과 같은 문제들이 발생할 수 있었습니다.

- 리소스 누수: S3 다운로드 성공 후 썸네일 생성 실패 시, 다운로드된 파일이 메모리에 남아있음
- 불완전한 에러 처리: 중간 단계 실패 시 이전 단계의 리소스가 제대로 정리되지 않음

이를 coroutineScope를 활용한 구조화된 동시성을 도입하여 개선하여 에러 케이스에서의 리소스 누수를 제거하고, 불필요한 재시도를 감소해 평균 응답 시간이 감소한 것을 확인했습니다.

## 🔁 변경 사항
- JMeter 테스트와 관련된 이전 [게시글](https://coordinated-muskmelon-1dd.notion.site/JMeter-20b52b8b99e580feaf28e54cb991fa3c?source=copy_link)도 함께 첨부합니다!
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
