### PR TITLE
[fix] 영상 조회 시 마지막 페이지일 때 커서 값을 -1로 설정해 순환 조회 처리

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostServiceImpl.kt
@@ -32,7 +32,7 @@ class PostServiceImpl(
     ): PostPageResponse {
         val postsInfoResponse = mapPostsToResponse(pageIds)
         val hasNext = shuffledPostIds.size > (startIndex + pageIds.size)
-        val nextCursor = startIndex + pageIds.size - 1
+        val nextCursor = if (!hasNext) -1 else startIndex + pageIds.size - 1
 
         return PostPageResponse.of(postsInfoResponse, hasNext, nextCursor)
     }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/post/service/PostServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/post/service/PostServiceImplTest.kt
@@ -7,9 +7,11 @@ import nmnb.domain.post.repository.PostRepository
 import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
@@ -17,7 +19,17 @@ class PostServiceImplTest(
     @Autowired private val userRepository: UserRepository,
     @Autowired private val postRepository: PostRepository,
     @Autowired private val postService: PostService,
+    @Autowired private var cacheManager: CacheManager,
 ) : IntegrationTestSupport() {
+
+    @AfterEach
+    fun tearDown() {
+        postRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+
+        cacheManager.getCache("postIds")?.clear()
+        cacheManager.getCache("shuffledIds")?.clear()
+    }
 
     @DisplayName("게시글을 랜덤 페이지 조회 시, 여러 번 요청하여 전체 게시글을 모두 조회할 수 있다")
     @Test
@@ -49,11 +61,32 @@ class PostServiceImplTest(
         assertThat(result1.hasNext).isTrue
 
         assertThat(result2.postInfo).hasSize(1)
-        assertThat(result2.nextCursor).isEqualTo(2)
         assertThat(result2.hasNext).isFalse
 
         assertThat(allResult).hasSize(3)
             .extracting("url")
             .containsExactlyInAnyOrder("url1", "url2", "url3")
+    }
+
+    @DisplayName("마지막 페이지를 조회할 경우, cursor 값은 -1이다.")
+    @Test
+    fun getPostsLastPage() {
+        // given
+        val user = User.fixture()
+        userRepository.save(user)
+
+        val post1 = Post.fixture(url = "url1", user = user)
+        val post2 = Post.fixture(url = "url2", user = user)
+        postRepository.saveAll(listOf(post1, post2))
+
+        val seed = 1234
+        val size = 2
+
+        // when
+        val request = PostPageServiceRequest(seed = seed, cursor = -1, size = size)
+        val result = postService.getPostPage(request)
+
+        // then
+        assertThat(result.nextCursor).isEqualTo(-1)
     }
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/post/repository/PostRepository.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/post/repository/PostRepository.kt
@@ -8,6 +8,5 @@ interface PostRepository : JpaRepository<Post, Long> {
     @Query("SELECT p.id FROM Post p")
     fun findAllPostId(): List<Long>
 
-    @Query("SELECT p FROM Post p WHERE p.id IN :ids")
-    fun findAllByIdIn(ids: List<Long>): List<Post>
+    fun findAllByIdIn(ids: Iterable<Long>): List<Post>
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #88

## 📌 개요
- 순환 조회 될 수 있게 마지막 페이지를 조회하는 경우 `nextCursor`값을 -1로 설정했습니다. 

## 🔁 변경 사항

## 📸 스크린샷
<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/647c4409-76c8-41b9-b3b9-c20c393c753c" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
