### PR TITLE
[fix] Docker 이미지 빌드 과정에 ffmpeg 포함

### DIFF
--- a/nmnb-webflux-bootstrap/Dockerfile
+++ b/nmnb-webflux-bootstrap/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-jdk-slim
 
+RUN apt-get update && apt-get install -y ffmpeg && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY nmnb-webflux-bootstrap/build/libs/*.jar /app/app.jar


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #91 

## 📌 개요
- 기존 컨테이너 실행 후 수동으로 ffmpeg 를 설치했으나, 도커 이미지 빌드 과정에 ffmpeg를 포함하도록 수정해 배포 및 실행 시 별도 설치 과정이 필요없게 함

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
