### PR TITLE
[fix] 썸네일 Queue 비어있을 때의 로그 제거로 로그 과다 출력 방지

### DIFF
--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/redis/ThumbnailWorker.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/infrastructure/external/redis/ThumbnailWorker.kt
@@ -50,7 +50,6 @@ class ThumbnailWorker(
                         processPayload(payload)
                         logger.info("Finished payload from queue---------")
                     } else {
-                        logger.info("No payload in queue")
                         delay(1000)
                     }
                 } catch (e: Exception) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #96 

## 📌 개요
- queue 삽입 로그 때문에 전체 로그 확인이 어려워 처리 과정의 로그 내용을 수정해 가독성을 높입니다.
=> 큐가 비어있을 때의 로그는 출력하지 않도록 수정했습니다. 


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
