### PR TITLE
[refactor] 캐시 만료 시간 제거 및 조건부 재설정으로 변경

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheEvictor.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheEvictor.kt
@@ -1,0 +1,15 @@
+package nmnb.application.domain.post.service
+
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.stereotype.Service
+
+@Service
+class PostCacheEvictor() {
+    @CacheEvict(cacheNames = ["postIds"])
+    fun refreshPostIds() {
+    }
+
+    @CacheEvict(cacheNames = ["shuffledIds"], key = "#seed")
+    fun refreshShuffledIds(seed: Int) {
+    }
+}

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheService.kt
@@ -1,7 +1,9 @@
 package nmnb.application.domain.post.service
 
+import nmnb.application.domain.post.service.dto.request.PostPageServiceRequest
+
 interface PostCacheService {
     fun getAllPostIds(): List<Long>
     fun getShuffledIds(ids: List<Long>, seed: Int): List<Long>
-    fun refreshPostcache(seed: Int)
+    fun refreshPostcache(request: PostPageServiceRequest)
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheService.kt
@@ -3,4 +3,5 @@ package nmnb.application.domain.post.service
 interface PostCacheService {
     fun getAllPostIds(): List<Long>
     fun getShuffledIds(ids: List<Long>, seed: Int): List<Long>
+    fun refreshPostcache(seed: Int)
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheServiceImpl.kt
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service
 @Service
 class PostCacheServiceImpl(
     private val postRepository: PostRepository,
+    private val postCacheEvictor: PostCacheEvictor,
 ) : PostCacheService {
     @Cacheable(cacheNames = ["postIds"])
     override fun getAllPostIds(): List<Long> = postRepository.findAllPostId()
@@ -15,5 +16,10 @@ class PostCacheServiceImpl(
     @Cacheable(cacheNames = ["shuffledIds"], key = "#seed")
     override fun getShuffledIds(ids: List<Long>, seed: Int): List<Long> {
         return RandomSelector.shuffleIds(ids, seed)
+    }
+
+    override fun refreshPostcache(seed: Int) {
+        postCacheEvictor.refreshPostIds()
+        postCacheEvictor.refreshShuffledIds(seed)
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostCacheServiceImpl.kt
@@ -1,5 +1,6 @@
 package nmnb.application.domain.post.service
 
+import nmnb.application.domain.post.service.dto.request.PostPageServiceRequest
 import nmnb.application.domain.post.utils.RandomSelector
 import nmnb.domain.post.repository.PostRepository
 import org.springframework.cache.annotation.Cacheable
@@ -18,8 +19,14 @@ class PostCacheServiceImpl(
         return RandomSelector.shuffleIds(ids, seed)
     }
 
-    override fun refreshPostcache(seed: Int) {
-        postCacheEvictor.refreshPostIds()
-        postCacheEvictor.refreshShuffledIds(seed)
+    override fun refreshPostcache(request: PostPageServiceRequest) {
+        if (request.cursor == INITIAL_CURSOR) {
+            postCacheEvictor.refreshPostIds()
+            postCacheEvictor.refreshShuffledIds(request.seed)
+        }
+    }
+
+    companion object {
+        private const val INITIAL_CURSOR = -1
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostServiceImpl.kt
@@ -16,6 +16,7 @@ class PostServiceImpl(
     private val postCacheService: PostCacheService,
 ) : PostService {
     override fun getPostPage(request: PostPageServiceRequest): PostPageResponse {
+        postCacheService.refreshPostcache(request)
         val allPostIds = postCacheService.getAllPostIds()
         val shuffledPostIds = postCacheService.getShuffledIds(allPostIds, request.seed)
 

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostServiceImpl.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/post/service/PostServiceImpl.kt
@@ -33,7 +33,7 @@ class PostServiceImpl(
     ): PostPageResponse {
         val postsInfoResponse = mapPostsToResponse(pageIds)
         val hasNext = shuffledPostIds.size > (startIndex + pageIds.size)
-        val nextCursor = if (!hasNext) -1 else startIndex + pageIds.size - 1
+        val nextCursor = if (!hasNext) INITIAL_CURSOR else startIndex + pageIds.size - 1
 
         return PostPageResponse.of(postsInfoResponse, hasNext, nextCursor)
     }
@@ -48,5 +48,9 @@ class PostServiceImpl(
     private fun fetchPostsByIds(pageIds: List<Long>): Map<Long, Post> {
         val posts = postRepository.findAllByIdIn(pageIds)
         return posts.associateBy { it.id!! }
+    }
+
+    companion object {
+        private const val INITIAL_CURSOR = -1
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/global/config/CacheConfig.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/global/config/CacheConfig.kt
@@ -6,7 +6,6 @@ import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import java.util.concurrent.TimeUnit
 
 @EnableCaching
 @Configuration
@@ -16,7 +15,6 @@ class CacheConfig {
         val cacheManager = CaffeineCacheManager()
         cacheManager.setCaffeine(
             Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
                 .maximumSize(100),
         )
         return cacheManager

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/post/service/PostCacheServiceTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/post/service/PostCacheServiceTest.kt
@@ -1,8 +1,10 @@
 package nmnb.application.domain.post.service
 
 import nmnb.application.IntegrationTestSupport
+import nmnb.application.domain.post.service.dto.request.PostPageServiceRequest
 import nmnb.domain.post.repository.PostRepository
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -20,10 +22,18 @@ class PostCacheServiceTest(
     @Autowired
     var postCacheService: PostCacheService,
     @Autowired
+    var postCacheEvictor: PostCacheEvictor,
+    @Autowired
     var cacheManager: CacheManager,
 ) : IntegrationTestSupport() {
     @MockBean
     lateinit var postRepository: PostRepository
+
+    @AfterEach
+    fun tearDown() {
+        cacheManager.getCache("postIds")?.clear()
+        cacheManager.getCache("shuffledIds")?.clear()
+    }
 
     @DisplayName("getAllPostIds 메서드는 캐시에 저장되며, 두 번째 호출부터는 캐시된 값이 반환된다")
     @Test
@@ -63,5 +73,28 @@ class PostCacheServiceTest(
         // then
         assertThat(result1).isEqualTo(result2)
         assertThat(result1).isNotEqualTo(result3)
+    }
+
+    @DisplayName("캐시를 무효화하는데 성공한다.")
+    @Test
+    fun refreshCache() {
+        // given
+        val ids = listOf(1L, 2L, 3L, 4L, 5L)
+        whenever(postRepository.findAllPostId()).thenReturn(ids)
+        val seed = 1234
+        val request = PostPageServiceRequest(seed = seed, cursor = -1, size = 7)
+
+        postCacheService.getAllPostIds()
+        postCacheService.getShuffledIds(ids, seed)
+
+        assertThat(cacheManager.getCache("postIds")?.get(SimpleKey.EMPTY)).isNotNull
+        assertThat(cacheManager.getCache("shuffledIds")?.get(seed)).isNotNull
+
+        // when
+        postCacheService.refreshPostcache(request)
+
+        // then
+        assertThat(cacheManager.getCache("postIds")?.get(SimpleKey.EMPTY)).isNull()
+        assertThat(cacheManager.getCache("shuffledIds")?.get(seed)).isNull()
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/post/service/PostServiceImplTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/post/service/PostServiceImplTest.kt
@@ -10,7 +10,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.cache.CacheManager
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,6 +25,9 @@ class PostServiceImplTest(
     @Autowired private val postService: PostService,
     @Autowired private var cacheManager: CacheManager,
 ) : IntegrationTestSupport() {
+
+    @MockBean
+    private lateinit var postCacheEvictor: PostCacheEvictor
 
     @AfterEach
     fun tearDown() {
@@ -88,5 +95,33 @@ class PostServiceImplTest(
 
         // then
         assertThat(result.nextCursor).isEqualTo(-1)
+    }
+
+    @DisplayName("조회 커서가 초기 값(-1)일 경우 캐시가 무효화된다.")
+    @Test
+    fun refreshCacheWhenInitialCursor() {
+        // given
+        val seed = 1234
+        val request = PostPageServiceRequest(seed = seed, cursor = -1, size = 7)
+
+        // when
+        postService.getPostPage(request)
+
+        // then
+        verify(postCacheEvictor, times(1)).refreshPostIds()
+    }
+
+    @DisplayName("조회 커서가 초기 값(-1)이 아닐 경우 캐시가 무효화되지 않는다.")
+    @Test
+    fun refreshCacheWhenNotInitialCursor() {
+        // given
+        val seed = 1234
+        val request = PostPageServiceRequest(seed = seed, cursor = 1, size = 7)
+
+        // when
+        postService.getPostPage(request)
+
+        // then
+        verify(postCacheEvictor, never()).refreshPostIds()
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #98

## 📌 개요
- 전체 post id와 셔플된 id 조회시 캐싱을 사용하고 있습니다. 
- 기존에는 **10분마다 캐시를 일괄적으로 갱신**하는 방법을 사용했습니다. 그런데 사용하다보니 해당 방법이 좋은 방법이 아니라는 것을 깨달았습니다....🥹 
=> 영상을 끝까지 보고 난 후에도 기존에 저장된 아이디들로만 조회가 되다보니 **10분이 지나야만 새로운 영상을 조회할 수 있는 것**이었습니다.

## 🔁 변경 사항
그래서 커서 값이 -1인 경우(1. 처음 접속해 영상들을 조회할 경우 2. 영상을 끝까지 조회한 후 다시 처음부터 조회할 경우) 이 두가지의 경우에 캐시를 무효화하고 재설정하는 전략을 적용했습니다. 

이렇게 설정할 경우 끝까지 조회하고 난 후, 다시 처음부터 조회할 때, 새롭게 등록된 영상들도 조회할 수 있게 됩니다. 
-> **캐시의 유효성을 사용자 경험에 맞춰 관리**하고 신규영상이 반영되도록 개선했습니다. 
-> 또한 불필요한 주기적 캐시 갱신을 제거해서 서버 부하를 줄였습니다!

<img width="600" height=auto alt="image" src="https://github.com/user-attachments/assets/fba4a838-5060-47b3-b498-dc62ad899c6d" />

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
