### PR TITLE
[refactor] 신고자 ID를 User 엔티티와의 관계로 변경 

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/PostReportService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/PostReportService.kt
@@ -21,7 +21,7 @@ class PostReportService(
     override fun validateReport(user: User, request: PostReportServiceRequest) {
         val post = fetchPost(request.targetId)
         validateNotSelfReport(user.id!!, post)
-        validateNotDuplicateReport(user.id!!, request.targetId)
+        validateNotDuplicateReport(user, request.targetId)
     }
 
     private fun fetchPost(targetId: Long): Post {
@@ -40,15 +40,15 @@ class PostReportService(
     }
 
     private fun validateNotDuplicateReport(
-        reporterId: String,
+        reporter: User,
         targetId: Long,
     ) {
-        if (reportRepository.existsPostReport(reporterId, targetId)) {
+        if (reportRepository.existsPostReport(reporter, targetId)) {
             throw ReportException(ErrorStatus.ALREADY_REPORTED)
         }
     }
 
     override fun createReport(user: User, request: PostReportServiceRequest): PostReport {
-        return PostReport(request.targetId, user.id!!, request.contentType)
+        return PostReport(request.targetId, user, request.contentType)
     }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/UserReportService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/UserReportService.kt
@@ -14,12 +14,13 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class UserReportService(
-    reportRepository: ReportRepository,
+    private val reportRepository: ReportRepository,
     private val userRepository: UserRepository,
 ) : ReportService<UserReport, UserReportServiceRequest>(reportRepository) {
     override fun validateReport(user: User, request: UserReportServiceRequest) {
         validateTarget(request.targetId)
         validateNotSelfReport(user.id!!, request.targetId)
+        validateNotDuplicateReport(user, request.targetId)
     }
 
     private fun validateTarget(targetId: String): User =
@@ -33,6 +34,15 @@ class UserReportService(
     ) {
         if (targetId == reporterId) {
             throw ReportException(ErrorStatus.CANNOT_REPORT_SELF)
+        }
+    }
+
+    private fun validateNotDuplicateReport(
+        reporter: User,
+        targetId: String,
+    ) {
+        if (reportRepository.existsUserReport(reporter, targetId)) {
+            throw ReportException(ErrorStatus.ALREADY_REPORTED)
         }
     }
 

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/UserReportService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/UserReportService.kt
@@ -37,5 +37,5 @@ class UserReportService(
     }
 
     override fun createReport(user: User, request: UserReportServiceRequest): UserReport =
-        UserReport(request.targetId, user.id!!, request.contentType)
+        UserReport(request.targetId, user, request.contentType)
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/PostReportServiceTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/PostReportServiceTest.kt
@@ -69,7 +69,7 @@ class PostReportServiceTest : IntegrationTestSupport() {
         val post = Post.fixture(user = poster)
         postRepository.save(post)
 
-        val report = PostReport.fixture(post.id!!, reporter.id!!)
+        val report = PostReport.fixture(post.id!!, reporter)
         reportRepository.save(report)
 
         val request = PostReportServiceRequest(post.id!!, ContentType.SEXUAL)

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/UserReportServiceTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/UserReportServiceTest.kt
@@ -5,6 +5,7 @@ import nmnb.application.domain.report.service.dto.request.UserReportServiceReque
 import nmnb.common.response.exception.ReportException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.domain.report.ContentType
+import nmnb.domain.report.UserReport
 import nmnb.domain.report.repository.ReportRepository
 import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
@@ -50,7 +51,7 @@ class UserReportServiceTest : IntegrationTestSupport() {
 
     @DisplayName("본인을 신고할 시 예외가 발생한다.")
     @Test
-    fun postReportSelf() {
+    fun userReportSelf() {
         // given
         val reporter = User.fixture()
         userRepository.save(reporter)
@@ -64,5 +65,29 @@ class UserReportServiceTest : IntegrationTestSupport() {
 
         // then
         Assertions.assertThat(exception.getCode()).isEqualTo(ErrorStatus.CANNOT_REPORT_SELF)
+    }
+
+    @DisplayName("사용자를 중복 신고할 시 예외가 발생한다.")
+    @Test
+    fun userReportDuplicate() {
+        // given
+        // given
+        val poster = User.fixture()
+        val reporter = User.fixture()
+        userRepository.saveAll(listOf(poster, reporter))
+
+        val report = UserReport.fixture(poster.id!!, reporter)
+        reportRepository.save(report)
+
+        val request = UserReportServiceRequest(poster.id!!, ContentType.SEXUAL)
+
+        // when
+        val exception = assertThrows<ReportException> {
+            userReportService.validateReport(reporter, request)
+        }
+
+        // then
+        Assertions.assertThat(exception.getCode()).isEqualTo(ErrorStatus.ALREADY_REPORTED)
+        Assertions.assertThat(reportRepository.findAll()).hasSize(1)
     }
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/PostReport.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/PostReport.kt
@@ -3,22 +3,28 @@ package nmnb.domain.report
 import jakarta.persistence.Column
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import nmnb.domain.user.User
 
 @Entity
 @DiscriminatorValue("POST")
 class PostReport(
     @Column(nullable = true)
-    val postId: Long? = null,
-    override val reporterId: String,
+    val targetPostId: Long? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false, insertable = false, updatable = false)
+    override val reporter: User,
     override val content: ContentType,
-) : Report(reporterId = reporterId, content = content) {
+) : Report(reporter = reporter, content = content) {
     companion object {
         fun fixture(
-            postId: Long,
-            reporterId: String,
+            targetId: Long,
+            reporter: User,
             content: ContentType = ContentType.SEXUAL,
         ): PostReport {
-            return PostReport(postId, reporterId, content)
+            return PostReport(targetId, reporter, content)
         }
     }
 }

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/Report.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/Report.kt
@@ -6,13 +6,17 @@ import jakarta.persistence.DiscriminatorType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import nmnb.domain.JpaBaseEntity
+import nmnb.domain.user.User
 
 @Entity
 @Table(name = "reports")
@@ -24,8 +28,9 @@ abstract class Report(
     @Column(name = "report_id")
     val id: Long? = null,
 
-    @Column(nullable = false)
-    val reporterId: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val reporter: User,
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/UserReport.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/UserReport.kt
@@ -3,12 +3,18 @@ package nmnb.domain.report
 import jakarta.persistence.Column
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import nmnb.domain.user.User
 
 @Entity
 @DiscriminatorValue("USER")
 class UserReport(
     @Column(nullable = true)
-    val userId: String? = null,
-    override val reporterId: String,
+    val targetUserId: String? = null,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false, insertable = false, updatable = false)
+    override val reporter: User,
     override val content: ContentType,
-) : Report(reporterId = reporterId, content = content)
+) : Report(reporter = reporter, content = content)

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/UserReport.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/UserReport.kt
@@ -17,4 +17,14 @@ class UserReport(
     @JoinColumn(name = "reporter_id", nullable = false, insertable = false, updatable = false)
     override val reporter: User,
     override val content: ContentType,
-) : Report(reporter = reporter, content = content)
+) : Report(reporter = reporter, content = content) {
+    companion object {
+        fun fixture(
+            targetUserId: String,
+            reporter: User,
+            content: ContentType = ContentType.SEXUAL,
+        ): UserReport {
+            return UserReport(targetUserId, reporter, content)
+        }
+    }
+}

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/repository/ReportRepository.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/repository/ReportRepository.kt
@@ -2,6 +2,7 @@ package nmnb.domain.report.repository
 
 import io.lettuce.core.dynamic.annotation.Param
 import nmnb.domain.report.Report
+import nmnb.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -10,7 +11,13 @@ import org.springframework.stereotype.Repository
 interface ReportRepository : JpaRepository<Report, Long> {
     @Query(
         "SELECT CASE WHEN COUNT(r) >0 THEN true ELSE false END FROM " +
-            "PostReport r WHERE r.reporterId=:reporterId AND r.postId=:targetId",
+            "PostReport r WHERE r.reporter=:reporter AND r.targetPostId=:targetId",
     )
-    fun existsPostReport(@Param("reporterId") reporterId: String, @Param("targetId") targetId: Long): Boolean
+    fun existsPostReport(@Param("reporter") reporter: User, @Param("targetId") targetId: Long): Boolean
+
+    @Query(
+        "SELECT CASE WHEN COUNT(r) >0 THEN true ELSE false END FROM " +
+            "UserReport r WHERE r.reporter=:reporter AND r.targetUserId=:targetId",
+    )
+    fun existsUserReport(@Param("reporter") reporter: User, @Param("targetId") targetId: String): Boolean
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #106

## 📌 개요
1. 신고자 관계 변경 : 기존에는 신고자 Id를 Long, String 형으로 저장했었는데, User 엔티티와의 `@ManyToOne` 관계로 수정했습니다. 
-> JPA의 외래 키 제약 조건을 활용해서 데이터베이스 수준에서 정합성을 보장하기 위함입니다. 
-> 신고 기능에서 **누가 신고했는가**는 중요한 정보라고 판단했습니다.
-> **신고 타깃 필**드들은 **기본 타입**을 유지했습니다. 신고 데이터를 조회할 때 불필요한 JOIN 연산을 피하기 위함이었습니다. Report 엔티티의 주 역할은 신고 기록을 남기는 것이고, 신고 대상의 상세 정보는 필요할 때 별도의 비즈니스 로직을 통해 조회하는 것이 지금으로는 더 효율적이라고 판단했습니다. 

2. 신고 대상 필드명 명확화 : 기존 userId, postId 로 표현되던 신고대상아이디들의 앞에 **target**을 추가했습니다. `postId-> targetPostId`, `userId-> targetUserId `로 수정해 명확하게 나타냈습니다. 


## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
