### PR TITLE
[refactor] 신고/차단 중복 검증을 DB제약으로 변경

### DIFF
--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/block/controller/BlockController.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/block/controller/BlockController.kt
@@ -27,7 +27,10 @@ class BlockController(
         summary = "사용자 차단 API",
         description = "사용자를 차단합니다. 차단한 사용자는 페이지에 조회되지 않습니다._숙희",
     )
-    @ApiResponses(ApiResponse(responseCode = "COMMON200", description = "성공입니다."))
+    @ApiResponses(
+        ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+        ApiResponse(responseCode = "BLOCK400", description = "이미 차단한적이 있습니다."),
+    )
     @PostMapping("/users/blocks")
     fun blockUser(
         @Parameter(name = "user", hidden = true) @AuthUser user: User,

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/block/service/UserBlockService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/block/service/UserBlockService.kt
@@ -1,12 +1,14 @@
 package nmnb.application.domain.block.service
 
 import nmnb.application.domain.block.service.dto.request.UserBlockServiceRequest
+import nmnb.common.response.exception.BlockException
 import nmnb.common.response.exception.UserException
 import nmnb.common.response.status.ErrorStatus
 import nmnb.domain.block.Block
 import nmnb.domain.block.repository.BlockRepository
 import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,7 +23,12 @@ class UserBlockService(
         val blockedUser = userRepository.findById(request.userId).orElseThrow {
             UserException(ErrorStatus.USER_NOT_FOUND)
         }
-        blockRepository.save(Block(blocker = user, blockedUser = blockedUser))
+
+        try {
+            blockRepository.save(Block(blocker = user, blockedUser = blockedUser))
+        } catch (e: DataIntegrityViolationException) {
+            throw BlockException(ErrorStatus.ALREADY_BLOCKED)
+        }
     }
 
     @Transactional

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/block/service/UserBlockService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/block/service/UserBlockService.kt
@@ -20,9 +20,7 @@ class UserBlockService(
 ) {
     @Transactional
     fun block(user: User, request: UserBlockServiceRequest) {
-        val blockedUser = userRepository.findById(request.userId).orElseThrow {
-            UserException(ErrorStatus.USER_NOT_FOUND)
-        }
+        val blockedUser = getBlockedUser(request)
 
         try {
             blockRepository.save(Block(blocker = user, blockedUser = blockedUser))
@@ -33,12 +31,15 @@ class UserBlockService(
 
     @Transactional
     fun unBlock(user: User, request: UserBlockServiceRequest) {
-        val blockedUser = userRepository.findById(request.userId).orElseThrow {
-            UserException(ErrorStatus.USER_NOT_FOUND)
-        }
+        val blockedUser = getBlockedUser(request)
         blockRepository.findByBlockerAndBlockedUser(user, blockedUser)
             ?.let { block ->
                 blockRepository.delete(block)
             }
     }
+
+    private fun getBlockedUser(request: UserBlockServiceRequest): User =
+        userRepository.findById(request.userId).orElseThrow {
+            UserException(ErrorStatus.USER_NOT_FOUND)
+        }
 }

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/PostReportService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/PostReportService.kt
@@ -21,7 +21,6 @@ class PostReportService(
     override fun validateReport(user: User, request: PostReportServiceRequest) {
         val post = fetchPost(request.targetId)
         validateNotSelfReport(user.id!!, post)
-        validateNotDuplicateReport(user, request.targetId)
     }
 
     private fun fetchPost(targetId: Long): Post {
@@ -36,15 +35,6 @@ class PostReportService(
     ) {
         if (post.user.id == reporterId) {
             throw ReportException(ErrorStatus.CANNOT_REPORT_SELF)
-        }
-    }
-
-    private fun validateNotDuplicateReport(
-        reporter: User,
-        targetId: Long,
-    ) {
-        if (reportRepository.existsPostReport(reporter, targetId)) {
-            throw ReportException(ErrorStatus.ALREADY_REPORTED)
         }
     }
 

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/ReportService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/ReportService.kt
@@ -1,14 +1,23 @@
 package nmnb.application.domain.report.service
 
+import nmnb.common.response.exception.ReportException
+import nmnb.common.response.status.ErrorStatus
 import nmnb.domain.report.Report
 import nmnb.domain.report.repository.ReportRepository
 import nmnb.domain.user.User
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.transaction.annotation.Transactional
 
 abstract class ReportService<R : Report, Request>(
     private val reportRepository: ReportRepository,
 ) {
-    fun save(report: R) = reportRepository.save(report)
+    fun save(report: R) {
+        try {
+            reportRepository.save(report)
+        } catch (e: DataIntegrityViolationException) {
+            throw ReportException(ErrorStatus.ALREADY_REPORTED)
+        }
+    }
 
     @Transactional
     open fun report(user: User, request: Request) {

--- a/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/UserReportService.kt
+++ b/nmnb-application/src/main/kotlin/nmnb/application/domain/report/service/UserReportService.kt
@@ -20,7 +20,6 @@ class UserReportService(
     override fun validateReport(user: User, request: UserReportServiceRequest) {
         validateTarget(request.targetId)
         validateNotSelfReport(user.id!!, request.targetId)
-        validateNotDuplicateReport(user, request.targetId)
     }
 
     private fun validateTarget(targetId: String): User =
@@ -34,15 +33,6 @@ class UserReportService(
     ) {
         if (targetId == reporterId) {
             throw ReportException(ErrorStatus.CANNOT_REPORT_SELF)
-        }
-    }
-
-    private fun validateNotDuplicateReport(
-        reporter: User,
-        targetId: String,
-    ) {
-        if (reportRepository.existsUserReport(reporter, targetId)) {
-            throw ReportException(ErrorStatus.ALREADY_REPORTED)
         }
     }
 

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/PostReportServiceTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/PostReportServiceTest.kt
@@ -13,6 +13,7 @@ import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -28,8 +29,12 @@ class PostReportServiceTest : IntegrationTestSupport() {
     @Autowired
     private lateinit var reportRepository: ReportRepository
 
-    @Autowired
     private lateinit var postReportService: PostReportService
+
+    @BeforeEach
+    fun setUp() {
+        postReportService = PostReportService(reportRepository, postRepository)
+    }
 
     @AfterEach
     fun tearDown() {
@@ -58,32 +63,6 @@ class PostReportServiceTest : IntegrationTestSupport() {
         assertThat(reportRepository.findAll()).hasSize(1)
     }
 
-    @DisplayName("중복 신고시 예외가 발생한다.")
-    @Test
-    fun postReportDuplicate() {
-        // given
-        val poster = User.fixture()
-        val reporter = User.fixture()
-        userRepository.saveAll(listOf(poster, reporter))
-
-        val post = Post.fixture(user = poster)
-        postRepository.save(post)
-
-        val report = PostReport.fixture(post.id!!, reporter)
-        reportRepository.save(report)
-
-        val request = PostReportServiceRequest(post.id!!, ContentType.SEXUAL)
-
-        // when
-        val exception = assertThrows<ReportException> {
-            postReportService.validateReport(reporter, request)
-        }
-
-        // then
-        assertThat(exception.getCode()).isEqualTo(ErrorStatus.ALREADY_REPORTED)
-        assertThat(reportRepository.findAll()).hasSize(1)
-    }
-
     @DisplayName("본인의 게시글을 신고할 시 예외가 발생한다.")
     @Test
     fun postReportSelf() {
@@ -103,5 +82,30 @@ class PostReportServiceTest : IntegrationTestSupport() {
 
         // then
         assertThat(exception.getCode()).isEqualTo(ErrorStatus.CANNOT_REPORT_SELF)
+    }
+
+    @DisplayName("중복 신고시 예외가 발생한다.")
+    @Test
+    fun postReportDuplicate() {
+        // given
+        val poster = User.fixture()
+        val reporter = User.fixture()
+        userRepository.saveAll(listOf(poster, reporter))
+
+        val post = Post.fixture(user = poster)
+        postRepository.save(post)
+
+        val report1 = PostReport.fixture(post.id!!, reporter)
+        val report2 = PostReport.fixture(post.id!!, reporter)
+        reportRepository.save(report1)
+
+        // when
+        val exception = assertThrows<ReportException> {
+            postReportService.save(report2)
+        }
+
+        // then
+        assertThat(exception.getCode()).isEqualTo(ErrorStatus.ALREADY_REPORTED)
+        assertThat(reportRepository.findAll()).hasSize(1)
     }
 }

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/ReportServiceConcurrencyTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/ReportServiceConcurrencyTest.kt
@@ -1,0 +1,80 @@
+package nmnb.application.domain.report.service
+
+import nmnb.application.IntegrationTestSupport
+import nmnb.domain.post.Post
+import nmnb.domain.post.repository.PostRepository
+import nmnb.domain.report.PostReport
+import nmnb.domain.report.repository.ReportRepository
+import nmnb.domain.user.User
+import nmnb.domain.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class ReportServiceConcurrencyTest : IntegrationTestSupport() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var reportRepository: ReportRepository
+
+    @Autowired
+    private lateinit var postReportService: PostReportService
+
+    @AfterEach
+    fun tearDown() {
+        reportRepository.deleteAllInBatch()
+        postRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("동일 게시글 신고 요청 시 중복 등록되지 않는다.")
+    @Test
+    fun report() {
+        // given
+        val threadCount = 10
+
+        val poster = User.fixture()
+        val reporter = User.fixture()
+        userRepository.saveAll(listOf(poster, reporter))
+
+        val post = Post.fixture(user = poster)
+        postRepository.save(post)
+
+        val report = PostReport.fixture(post.id!!, reporter)
+        reportRepository.save(report)
+
+        // when
+        val executorService = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+
+        try {
+            repeat(threadCount) {
+                executorService.submit {
+                    try {
+                        postReportService.save(report)
+                    } finally {
+                        latch.countDown()
+                    }
+                }
+            }
+
+            latch.await()
+        } finally {
+            executorService.shutdown()
+            executorService.awaitTermination(1, TimeUnit.MINUTES)
+        }
+
+        // then
+        val allReport = reportRepository.findAll()
+        assertThat(allReport).hasSize(1)
+    }
+}

--- a/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/UserReportServiceTest.kt
+++ b/nmnb-application/src/test/kotlin/nmnb/application/domain/report/service/UserReportServiceTest.kt
@@ -11,6 +11,7 @@ import nmnb.domain.user.User
 import nmnb.domain.user.repository.UserRepository
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,8 +24,12 @@ class UserReportServiceTest : IntegrationTestSupport() {
     @Autowired
     private lateinit var reportRepository: ReportRepository
 
-    @Autowired
     private lateinit var userReportService: UserReportService
+
+    @BeforeEach
+    fun setUp() {
+        userReportService = UserReportService(reportRepository, userRepository)
+    }
 
     @AfterEach
     fun tearDown() {
@@ -71,19 +76,17 @@ class UserReportServiceTest : IntegrationTestSupport() {
     @Test
     fun userReportDuplicate() {
         // given
-        // given
         val poster = User.fixture()
         val reporter = User.fixture()
         userRepository.saveAll(listOf(poster, reporter))
 
-        val report = UserReport.fixture(poster.id!!, reporter)
-        reportRepository.save(report)
-
-        val request = UserReportServiceRequest(poster.id!!, ContentType.SEXUAL)
+        val report1 = UserReport.fixture(poster.id!!, reporter)
+        val report2 = UserReport.fixture(poster.id!!, reporter)
+        reportRepository.save(report1)
 
         // when
         val exception = assertThrows<ReportException> {
-            userReportService.validateReport(reporter, request)
+            userReportService.save(report2)
         }
 
         // then

--- a/nmnb-common/src/main/kotlin/nmnb/common/response/exception/BlockException.kt
+++ b/nmnb-common/src/main/kotlin/nmnb/common/response/exception/BlockException.kt
@@ -1,0 +1,5 @@
+package nmnb.common.response.exception
+
+import nmnb.common.response.base.BaseErrorCode
+
+class BlockException(code: BaseErrorCode) : GeneralException(code)

--- a/nmnb-common/src/main/kotlin/nmnb/common/response/status/ErrorStatus.kt
+++ b/nmnb-common/src/main/kotlin/nmnb/common/response/status/ErrorStatus.kt
@@ -47,6 +47,9 @@ enum class ErrorStatus(
     INVALID_POST_TARGET_ID(HttpStatus.NOT_FOUND, "REPORT401", "유효한 Post 아이디가 아닙니다."),
     CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST, "REPORT402", "본인을 신고할 수 없습니다."),
     ALREADY_REPORTED(HttpStatus.BAD_REQUEST, "REPORT403", "이미 신고한적이 있습니다."),
+
+    // BLOCK
+    ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "BLOCK400", "이미 차단한적이 있습니다."),
     ;
 
     override fun getReasonHttpStatus(): ErrorReasonDTO {

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/Report.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/Report.kt
@@ -15,11 +15,18 @@ import jakarta.persistence.InheritanceType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import nmnb.domain.JpaBaseEntity
 import nmnb.domain.user.User
 
 @Entity
-@Table(name = "reports")
+@Table(
+    name = "reports",
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["user_id", "target_post_id"]),
+        UniqueConstraint(columnNames = ["user_id", "target_user_id"]),
+    ],
+)
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "report_type", discriminatorType = DiscriminatorType.STRING)
 abstract class Report(

--- a/nmnb-domain/src/main/kotlin/nmnb/domain/report/repository/ReportRepository.kt
+++ b/nmnb-domain/src/main/kotlin/nmnb/domain/report/repository/ReportRepository.kt
@@ -1,23 +1,8 @@
 package nmnb.domain.report.repository
 
-import io.lettuce.core.dynamic.annotation.Param
 import nmnb.domain.report.Report
-import nmnb.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ReportRepository : JpaRepository<Report, Long> {
-    @Query(
-        "SELECT CASE WHEN COUNT(r) >0 THEN true ELSE false END FROM " +
-            "PostReport r WHERE r.reporter=:reporter AND r.targetPostId=:targetId",
-    )
-    fun existsPostReport(@Param("reporter") reporter: User, @Param("targetId") targetId: Long): Boolean
-
-    @Query(
-        "SELECT CASE WHEN COUNT(r) >0 THEN true ELSE false END FROM " +
-            "UserReport r WHERE r.reporter=:reporter AND r.targetUserId=:targetId",
-    )
-    fun existsUserReport(@Param("reporter") reporter: User, @Param("targetId") targetId: String): Boolean
-}
+interface ReportRepository : JpaRepository<Report, Long>


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #109

## 📌 개요
1. 기존 데이터베이스에서 직접 조회해 중복 여부를 검사했었는데, 이를 **DB단에서 검증**하도록 수정했습니다. 
2. Report, Block 엔티티는 DB 제약 조건을 가지며, 이를 통해 중복 등록을 방지합니다. 
3.  DB 단 점증으로 변경한 이유는 2가지 입니다. 
-애플리케이션 레벨에서 중복 체크시 동시성 문제 발생 가능 
-DB 제약 조건을 화용하면 데이터 무결성 보장 가능 

## 🔁 변경 사항

## 📸 스크린샷
<img width="500" height=auto alt="image" src="https://github.com/user-attachments/assets/045094e3-689c-498c-b076-30b4ae6bfd3d" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
