### PR TITLE
[refactor] 유저 생성 시간 직접 입력하도록 수정

### DIFF
--- a/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/auth/service/AuthServiceImpl.kt
+++ b/nmnb-webflux/src/main/kotlin/nmnb/webflux/global/auth/service/AuthServiceImpl.kt
@@ -14,11 +14,11 @@ import org.springframework.data.r2dbc.core.R2dbcEntityTemplate
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.ReactiveTransactionManager
-import org.springframework.transaction.reactive.TransactionalOperator
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.switchIfEmpty
 import java.time.Instant
+import java.time.LocalDateTime
 
 @Service
 class AuthServiceImpl(
@@ -31,9 +31,6 @@ class AuthServiceImpl(
     transactionalManager: ReactiveTransactionManager,
     private val r2dbcEntityTemplate: R2dbcEntityTemplate,
 ) : AuthService {
-
-    private val txOperator = TransactionalOperator.create(transactionalManager)
-
     override fun appleLogin(request: AppleLoginServiceRequest, deviceId: String): Mono<AuthUserResponse> {
         // 토큰 검증
         val claims = validateAppleIdToken(request.identityToken)
@@ -83,11 +80,15 @@ class AuthServiceImpl(
     }
 
     private fun createUser(email: String): Mono<R2dbcUser> {
+        val now = LocalDateTime.now()
         val newUser = R2dbcUser(
             id = CustomIdGenerator.generateId(),
             email = email,
             profileImage = s3Properties.s3.defaultProfileImageUrl,
-        )
+        ).apply {
+            createdAt = now
+            modifiedAt = now
+        }
         return r2dbcEntityTemplate.insert(newUser)
             .onErrorMap { throwable ->
                 AuthException(ErrorStatus.USER_CREATION_FAILED)


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #134 

## 📌 개요
- @CreatedDate는 INSERT 시에만 작동해야 하는데, r2dbcEntityTemplate.insert() 를 사용해서 불안정하게 작동 -> 그냥 둘다 생성시에 직접 입력해주는 방식으로 변경

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
